### PR TITLE
Fix tsce_chat import path

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ import pdfplumber
 # -------------------------------------------------------------------
 # Compatibility shim: make tsce_chat look like the old tsce_demo API
 # -------------------------------------------------------------------
-import tsce_chat as tsce_demo
+from tsce_agent_demo import tsce_chat as tsce_demo
 
 # Expose variables expected by legacy code
 import os


### PR DESCRIPTION
## Summary
- update `app.py` to import `tsce_chat` from the `tsce_agent_demo` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683b6219c5f08323b615c615987e1f4c