### PR TITLE
Update requirements for Streamlit app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ matplotlib
 torch
 scipy
 pdfplumber
+openai
+ollama


### PR DESCRIPTION
## Summary
- include `openai` and `ollama` dependencies required by `app.py` and `tsce_chat.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683b662a15608323914cdb564fb02b44