### PR TITLE
Add Planner agent

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -1,0 +1,27 @@
+"""Simple planning agent."""
+from __future__ import annotations
+
+from typing import List
+
+from .base import BaseAgent  # type: ignore
+
+
+class Planner(BaseAgent):
+    """Generate a numbered plan from the agent's context."""
+
+    def act(self) -> List[str]:
+        """Return a step-by-step plan derived from ``self.context``.
+
+        The method looks for ``self.context`` (a string) and splits it into
+        individual statements. Each statement becomes a numbered step.
+        """
+        context = getattr(self, "context", "")
+        if not isinstance(context, str) or not context.strip():
+            return ["Step 1: No context provided."]
+
+        # Split on newlines first; fall back to sentences.
+        parts = [p.strip() for p in context.splitlines() if p.strip()]
+        if len(parts) <= 1:
+            parts = [p.strip() for p in context.split(".") if p.strip()]
+
+        return [f"Step {i + 1}: {part}" for i, part in enumerate(parts)]


### PR DESCRIPTION
## Summary
- implement `Planner` agent for generating numbered plans

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845b93bba5c8323ac764682d500a8f7