### PR TITLE
Add simple script writer agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Lightweight helper agents for TSCE demo."""
+
+from . import script_writer
+
+__all__ = ["script_writer"]

--- a/agents/script_writer.py
+++ b/agents/script_writer.py
@@ -1,0 +1,42 @@
+import re
+import textwrap
+
+
+def act(request: str) -> str:
+    """Return a short Python code snippet for the given request.
+
+    The implementation is intentionally lightweight and recognises only a few
+    common patterns.  If the request cannot be handled, a comment describing
+    the limitation is returned instead of code.
+    """
+    lower = request.lower()
+
+    if "hello" in lower and "world" in lower:
+        return 'print("Hello, world!")'
+
+    m = re.search(r"fibonacci(?: up to)? (\d+)", lower)
+    if m:
+        n = int(m.group(1))
+        return textwrap.dedent(f"""
+            def fib(n):
+                a, b = 0, 1
+                result = []
+                for _ in range(n):
+                    result.append(a)
+                    a, b = b, a + b
+                return result
+
+            print(fib({n}))
+        """).strip()
+
+    m = re.search(r"factorial(?: of)? (\d+)", lower)
+    if m:
+        n = int(m.group(1))
+        return textwrap.dedent(f"""
+            def factorial(n):
+                return 1 if n <= 1 else n * factorial(n-1)
+
+            print(factorial({n}))
+        """).strip()
+
+    return f"# TODO: unable to generate script for: {request}"


### PR DESCRIPTION
## Summary
- add script writer agent that emits short Python code snippets
- expose it from the agents package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845b93f8c548323940836e808a70cc6