### PR TITLE
Add script QA helper

### DIFF
--- a/agents/script_qa.py
+++ b/agents/script_qa.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Tuple
+
+
+def run_tests(path: str | os.PathLike) -> Tuple[bool, str]:
+    """Run tests located at ``path``.
+
+    ``path`` may point to a single file or a directory containing tests.  If
+    the target looks like a test suite (a directory or a ``*_test.py`` file),
+    ``pytest`` is invoked.  Otherwise the file is executed directly with the
+    current Python interpreter.
+
+    Returns a tuple ``(success, details)`` where ``success`` is ``True`` when
+    the command exits with a zero status code and ``details`` contains the
+    combined stdout/stderr output.
+    """
+    target = Path(path)
+    if target.is_dir() or target.name.endswith("_test.py"):
+        cmd = ["pytest", str(target), "-q"]
+    else:
+        cmd = [sys.executable, str(target)]
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    output = proc.stdout + proc.stderr
+    return proc.returncode == 0, output
+
+__all__ = ["run_tests"]


### PR DESCRIPTION
## Summary
- add `agents/script_qa.py` with a `run_tests` function

## Testing
- `python -m py_compile agents/script_qa.py`
- `python - <<'PY'
from agents.script_qa import run_tests
success, details = run_tests('tsce_agent_demo/tsce_agent_test.py')
print('success', success)
print(details.splitlines()[:5])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6845b940fa908323b477e8de87b9cac9