### PR TITLE
Add Leader agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent utilities."""
+
+from .leader import BaseAgent, Leader
+
+__all__ = ["BaseAgent", "Leader"]

--- a/agents/leader.py
+++ b/agents/leader.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List
+
+
+class BaseAgent:
+    """Minimal base agent with conversation state."""
+
+    def __init__(self, name: str = "agent") -> None:
+        self.name = name
+        self.history: List[str] = []
+
+    def observe(self, message: str) -> None:
+        """Record a message from another agent/user."""
+        self.history.append(message)
+
+    def act(self) -> str:  # pragma: no cover - to be implemented by subclasses
+        raise NotImplementedError
+
+
+@dataclass
+class Leader(BaseAgent):
+    """Simple leader agent that issues high level goals sequentially."""
+
+    goals: List[str] = field(default_factory=list)
+    step: int = 0
+
+    def act(self) -> str:
+        """Return the next goal or indicate completion."""
+        if self.step < len(self.goals):
+            goal = self.goals[self.step]
+            self.step += 1
+            self.history.append(goal)
+            return goal
+        return "All goals completed."


### PR DESCRIPTION
## Summary
- implement simple `Leader` agent with state tracking in new `agents/leader.py`
- expose `BaseAgent` and `Leader` via `agents/__init__.py`

## Testing
- `python -m compileall -q agents`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845b93a13108323919345662ce0240e