### PR TITLE
Refactor script utilities into agents

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,10 +1,21 @@
 """Agent utilities."""
-from .leader import BaseAgent, Leader
-from .simulator import run_simulation
-from . import script_writer
-from .researcher import Researcher
-from .base_agent import BaseAgent
+
+from .base import BaseAgent
+from .leader import Leader
 from .scientist import Scientist
+from .researcher import Researcher
+from .script_writer import ScriptWriter
+from .script_qa import ScriptQA
+from .simulator import Simulator
+from .evaluator import Evaluator
 
-__all__ = ["BaseAgent", "Scientist", "script_writer",  "Leader"]
-
+__all__ = [
+    "BaseAgent",
+    "Leader",
+    "Scientist",
+    "Researcher",
+    "ScriptWriter",
+    "ScriptQA",
+    "Simulator",
+    "Evaluator",
+]

--- a/agents/evaluator.py
+++ b/agents/evaluator.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
+from .base import BaseAgent
 
-class Evaluator:
-    """Utility class that inspects a TSCE results directory."""
+
+class Evaluator(BaseAgent):
+    """Utility agent that inspects a TSCE results directory."""
 
     def __init__(self, results_dir: str | Path) -> None:
+        super().__init__(name="Evaluator")
         self.results_dir = Path(results_dir)
 
     # ------------------------------------------------------------------
@@ -54,3 +57,6 @@ class Evaluator:
             f"({data['tsce_rate']:.1%})."
         )
         return {"summary": summary, "success": improved}
+
+
+__all__ = ["Evaluator"]

--- a/agents/script_qa.py
+++ b/agents/script_qa.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import Tuple
 
+from .base import BaseAgent
+
 
 def run_tests(path: str | os.PathLike) -> Tuple[bool, str]:
     """Run tests located at ``path``.
@@ -28,4 +30,17 @@ def run_tests(path: str | os.PathLike) -> Tuple[bool, str]:
     output = proc.stdout + proc.stderr
     return proc.returncode == 0, output
 
-__all__ = ["run_tests"]
+
+class ScriptQA(BaseAgent):
+    """Agent that executes a script's tests."""
+
+    def __init__(self) -> None:
+        super().__init__(name="ScriptQA")
+
+    # ------------------------------------------------------------------
+    def act(self, path: str | os.PathLike) -> Tuple[bool, str]:
+        """Run tests at ``path`` and return ``(success, details)``."""
+        return run_tests(path)
+
+
+__all__ = ["ScriptQA", "run_tests"]

--- a/agents/script_writer.py
+++ b/agents/script_writer.py
@@ -1,42 +1,56 @@
+from __future__ import annotations
+
 import re
 import textwrap
 
+from .base import BaseAgent
 
-def act(request: str) -> str:
-    """Return a short Python code snippet for the given request.
 
-    The implementation is intentionally lightweight and recognises only a few
-    common patterns.  If the request cannot be handled, a comment describing
-    the limitation is returned instead of code.
-    """
-    lower = request.lower()
+class ScriptWriter(BaseAgent):
+    """Return a short Python snippet for a textual request."""
 
-    if "hello" in lower and "world" in lower:
-        return 'print("Hello, world!")'
+    def __init__(self) -> None:
+        super().__init__(name="ScriptWriter")
 
-    m = re.search(r"fibonacci(?: up to)? (\d+)", lower)
-    if m:
-        n = int(m.group(1))
-        return textwrap.dedent(f"""
-            def fib(n):
-                a, b = 0, 1
-                result = []
-                for _ in range(n):
-                    result.append(a)
-                    a, b = b, a + b
-                return result
+    # ------------------------------------------------------------------
+    def act(self, request: str) -> str:
+        """Return a short Python code snippet for ``request``.
 
-            print(fib({n}))
-        """).strip()
+        The implementation is intentionally lightweight and recognises only a
+        few common patterns.  If the request cannot be handled, a comment
+        describing the limitation is returned instead of code.
+        """
+        lower = request.lower()
 
-    m = re.search(r"factorial(?: of)? (\d+)", lower)
-    if m:
-        n = int(m.group(1))
-        return textwrap.dedent(f"""
-            def factorial(n):
-                return 1 if n <= 1 else n * factorial(n-1)
+        if "hello" in lower and "world" in lower:
+            return 'print("Hello, world!")'
 
-            print(factorial({n}))
-        """).strip()
+        m = re.search(r"fibonacci(?: up to)? (\d+)", lower)
+        if m:
+            n = int(m.group(1))
+            return textwrap.dedent(f"""
+                def fib(n):
+                    a, b = 0, 1
+                    result = []
+                    for _ in range(n):
+                        result.append(a)
+                        a, b = b, a + b
+                    return result
 
-    return f"# TODO: unable to generate script for: {request}"
+                print(fib({n}))
+            """).strip()
+
+        m = re.search(r"factorial(?: of)? (\d+)", lower)
+        if m:
+            n = int(m.group(1))
+            return textwrap.dedent(f"""
+                def factorial(n):
+                    return 1 if n <= 1 else n * factorial(n-1)
+
+                print(factorial({n}))
+            """).strip()
+
+        return f"# TODO: unable to generate script for: {request}"
+
+
+__all__ = ["ScriptWriter"]

--- a/agents/simulator.py
+++ b/agents/simulator.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import sys
 import time
 
+from .base import BaseAgent
+
 
 def run_simulation(path: str) -> str:
     """Execute a Python file and store the result in ``results/``.
@@ -41,3 +43,18 @@ def run_simulation(path: str) -> str:
         f.write(f"\n--- return code: {proc.returncode} ---\n")
 
     return str(log_file)
+
+
+class Simulator(BaseAgent):
+    """Execute Python scripts and record the output."""
+
+    def __init__(self) -> None:
+        super().__init__(name="Simulator")
+
+    # ------------------------------------------------------------------
+    def act(self, path: str) -> str:
+        """Run ``path`` and return the log file location."""
+        return run_simulation(path)
+
+
+__all__ = ["Simulator", "run_simulation"]


### PR DESCRIPTION
## Summary
- convert script_writer into `ScriptWriter` agent
- create `ScriptQA` agent around run_tests
- create `Simulator` agent around run_simulation
- make Evaluator derive from `BaseAgent`
- update exports in `agents/__init__.py`

## Testing
- `python -m compileall -q agents`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845e399e020832396074d33bc8808b1