### PR TITLE
Add orchestrator group chat module

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -3,19 +3,23 @@
 from .base import BaseAgent
 from .leader import Leader
 from .scientist import Scientist
+from .planner import Planner
 from .researcher import Researcher
 from .script_writer import ScriptWriter
 from .script_qa import ScriptQA
 from .simulator import Simulator
 from .evaluator import Evaluator
+from .orchestrator import Orchestrator
 
 __all__ = [
     "BaseAgent",
     "Leader",
+    "Planner",
     "Scientist",
     "Researcher",
     "ScriptWriter",
     "ScriptQA",
     "Simulator",
     "Evaluator",
+    "Orchestrator",
 ]

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+from .leader import Leader
+from .planner import Planner
+from .scientist import Scientist
+from tsce_agent_demo.tsce_chat import TSCEChat
+
+
+class Orchestrator:
+    """Coordinate a simple round-robin conversation between agents."""
+
+    def __init__(self, goals: List[str], *, model: str | None = None) -> None:
+        self.leader = Leader(goals=goals)
+        self.planner = Planner(name="Planner")
+        self.scientist = Scientist(name="Scientist")
+        self.chat = TSCEChat(model=model)
+        self.history: List[Dict[str, str]] = []
+
+    # ------------------------------------------------------------------
+    def run(self) -> List[Dict[str, str]]:
+        """Run the group chat until a terminate token is observed."""
+        while True:
+            goal = self.leader.act()
+            self.history.append({"role": "leader", "content": goal})
+            if "terminate" in goal.lower():
+                break
+
+            plan_prompt = f"You are Planner. Devise a brief plan for: {goal}"
+            plan = self.chat(plan_prompt).content
+            self.history.append({"role": "planner", "content": plan})
+            if "terminate" in plan.lower():
+                break
+
+            sci_prompt = (
+                "You are Scientist. Based on this plan, provide your analysis:\n"
+                f"{plan}"
+            )
+            answer = self.chat(sci_prompt).content
+            self.history.append({"role": "scientist", "content": answer})
+            if "terminate" in answer.lower():
+                break
+        return self.history
+
+
+__all__ = ["Orchestrator"]
+


### PR DESCRIPTION
## Summary
- implement `Orchestrator` for a basic Leader–Planner–Scientist loop
- export new class via `agents.__init__`
- use `TSCEChat` for all LLM calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845eab1c1b88323aa80319df37a1df8