### PR TITLE
Add hypothesis recording utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Intuition: Imagine you ask a model, “Summarize this 1,000-word legal brief.”
 | `tsce_agent_demo/results/` | Entropy, KL, cosine-violin plots ready to share. |
 | `.env.example` | Copy → `.env`, add your keys. |
 | `prompts/phase1.txt`, `prompts/phase2.txt` | Default templates for each phase |
+| `agents/hypothesis.py` | Record agreed hypothesis and emit `TERMINATE` |
 
 Works with **OpenAI Cloud**, **Azure OpenAI**, or any **Ollama / vLLM** endpoint.
 ✨ New: we now load the Phase 1 and Phase 2 prompts from prompts/phase1.txt and prompts/phase2.txt, making it easy to swap in your own prompt templates.

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -10,6 +10,7 @@ from .script_qa import ScriptQA
 from .simulator import Simulator
 from .evaluator import Evaluator
 from .orchestrator import Orchestrator
+from .hypothesis import record_agreed_hypothesis, TERMINATE_TOKEN
 
 __all__ = [
     "BaseAgent",
@@ -22,4 +23,6 @@ __all__ = [
     "Simulator",
     "Evaluator",
     "Orchestrator",
+    "record_agreed_hypothesis",
+    "TERMINATE_TOKEN",
 ]

--- a/agents/hypothesis.py
+++ b/agents/hypothesis.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from .researcher import Researcher
+
+TERMINATE_TOKEN = "TERMINATE"
+
+
+def record_agreed_hypothesis(sci_view: str, res_view: str, *, researcher: Researcher | None = None) -> str | None:
+    """Write the agreed hypothesis to ``leading_hypothesis.txt`` and return the terminate token.
+
+    Parameters
+    ----------
+    sci_view : str
+        Hypothesis proposed by the Scientist.
+    res_view : str
+        Hypothesis echoed or proposed by the Researcher.
+    researcher : Researcher | None, optional
+        Researcher instance used to write the file. A new one is created if omitted.
+
+    Returns
+    -------
+    str | None
+        ``TERMINATE_TOKEN`` when the hypotheses match (case-insensitive), ``None`` otherwise.
+    """
+    if sci_view.strip().lower() == res_view.strip().lower():
+        agent = researcher or Researcher()
+        agent.write_file("leading_hypothesis.txt", sci_view)
+        return TERMINATE_TOKEN
+    return None
+
+__all__ = ["record_agreed_hypothesis", "TERMINATE_TOKEN"]


### PR DESCRIPTION
## Summary
- add `record_agreed_hypothesis` helper to save consensus to `leading_hypothesis.txt`
- expose helper through `agents.__init__`
- document new module in `README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845ed41d1e083238d702f9f757978ab