### PR TITLE
Use TSCEChat in Researcher

### DIFF
--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import pytest
+
+import agents.researcher as researcher_mod
+
+class DummyReply:
+    def __init__(self, content):
+        self.content = content
+        self.anchor = ""
+
+class DummyChat:
+    def __init__(self, *args, **kwargs):
+        self.called_with = None
+    def __call__(self, messages):
+        self.called_with = messages
+        return DummyReply("ack:" + messages[-1]["content"])
+
+def test_send_message_history(monkeypatch):
+    dummy = DummyChat()
+    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: dummy)
+    r = researcher_mod.Researcher(model="test-model")
+    result = r.send_message("hello")
+    assert result == "ack:hello"
+    assert r.history[-2:] == ["hello", "ack:hello"]
+    assert dummy.called_with[0]["role"] == "system"
+
+def test_env_model(monkeypatch):
+    captured = {}
+    def fake_chat(model=None):
+        captured["model"] = model
+        return DummyChat()
+    monkeypatch.setattr(researcher_mod, "TSCEChat", fake_chat)
+    monkeypatch.setenv("MODEL_NAME", "env-model")
+    r = researcher_mod.Researcher()
+    assert captured["model"] == "env-model"
+


### PR DESCRIPTION
## Summary
- refactor `Researcher` to rely on `TSCEChat`
- read model name from `MODEL_NAME` environment variable
- provide stub-based unit tests for the researcher agent

## Testing
- `pytest tests/test_researcher.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845f3ab6d408323bf72b2d4abee8e33