### PR TITLE
Add simulation log evaluator

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -122,6 +122,8 @@ class Orchestrator:
                 if self.stages.get("simulate"):
                     log_path = self.simulator.act(path)
                     self.history.append({"role": "simulator", "content": log_path})
+                    sim_result = self.evaluator.parse_simulator_log(log_path)
+                    self.history.append({"role": "evaluator", "content": sim_result["summary"]})
 
             # --- Evaluation -------------------------------------------------
             if self.stages.get("evaluate"):


### PR DESCRIPTION
## Summary
- parse simulator logs to check return codes
- write a `.summary` file next to each log
- call new evaluation after running the simulator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845fa48921883238bd52f31c21d2fd0