### PR TITLE
Add hypothesis directory setup

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -31,6 +31,8 @@ class Orchestrator:
         self.judge_panel = JudgePanel()
         self.output_dir = output_dir
         os.makedirs(self.output_dir, exist_ok=True)
+        self.hypothesis_dir = os.path.join(self.output_dir, "hypothesis")
+        os.makedirs(self.hypothesis_dir, exist_ok=True)
         self.chat = TSCEChat(model=model)
         self.history: List[Dict[str, str]] = []
         self.stages = {
@@ -99,7 +101,7 @@ class Orchestrator:
                 token = record_agreed_hypothesis(
                     sci_hyp,
                     res_hyp,
-                    path=os.path.join(self.output_dir, "leading_hypothesis.txt"),
+                    path=os.path.join(self.hypothesis_dir, "leading_hypothesis.txt"),
                     researcher=self.researcher,
                 )
                 if token:

--- a/tests/test_orchestrator_output.py
+++ b/tests/test_orchestrator_output.py
@@ -51,5 +51,6 @@ def test_output_files_created(tmp_path, monkeypatch):
 
     orch.run()
 
-    assert (tmp_path / "leading_hypothesis.txt").exists()
+    assert (tmp_path / "hypothesis").is_dir()
+    assert (tmp_path / "hypothesis" / "leading_hypothesis.txt").exists()
     assert (tmp_path / "research.txt").exists()


### PR DESCRIPTION
## Summary
- add a repository-level `hypothesis/` folder
- create a `hypothesis` subdirectory when the `Orchestrator` starts
- keep `leading_hypothesis.txt` under that folder
- update orchestrator tests for the new path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462e90ceec8323b9a9f266afa73372