### PR TITLE
Implement golden thread for ScriptWriter

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -111,7 +111,7 @@ class Orchestrator:
 
             # --- Script writing -------------------------------------------
             if self.stages.get("script"):
-                script = self.script_writer.act(plan)
+                script, gid = self.script_writer.act(plan)
                 self.history.append({"role": "script_writer", "content": script})
                 path = os.path.join(
                     self.hypothesis_dir,

--- a/tests/test_script_writer.py
+++ b/tests/test_script_writer.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agents.script_writer as script_writer_mod
+import agents.base_agent as base_agent_mod
+
+class DummyChat:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, prompt):
+        r = types.SimpleNamespace()
+        r.content = "dummy"
+        return r
+
+def test_golden_thread_comment_unique(monkeypatch):
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    sw = script_writer_mod.ScriptWriter()
+    script1, gid1 = sw.act("hello world")
+    script2, gid2 = sw.act("hello world")
+    assert script1.startswith(f"# GOLDEN_THREAD:{gid1}")
+    assert script2.startswith(f"# GOLDEN_THREAD:{gid2}")
+    assert gid1 != gid2


### PR DESCRIPTION
## Summary
- generate a unique `GOLDEN_THREAD` comment for every script
- return `(script, id)` from `ScriptWriter.act`
- update orchestrator to handle new tuple
- test that `ScriptWriter` embeds unique IDs in scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464a383b9c832392eda4f80eaf020e