### PR TITLE
Add GOLDEN_THREAD check for ScriptQA

### DIFF
--- a/tests/test_script_qa.py
+++ b/tests/test_script_qa.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agents.script_qa as script_qa_mod
+
+
+def test_run_tests_requires_golden_thread(tmp_path):
+    script = tmp_path / "script.py"
+    script.write_text("print('hi')")
+    success, output = script_qa_mod.run_tests(script)
+    assert not success
+    assert "GOLDEN_THREAD" in output
+
+
+def test_run_tests_executes_when_marker_present(tmp_path):
+    script = tmp_path / "script.py"
+    script.write_text("# GOLDEN_THREAD:1\nprint('hi')")
+    success, output = script_qa_mod.run_tests(script)
+    assert success
+    assert "hi" in output


### PR DESCRIPTION
## Summary
- enforce presence of a `# GOLDEN_THREAD` marker before running tests
- add unit tests for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464df8f618832393639d5209197199