### PR TITLE
Store QA success in history

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -122,7 +122,11 @@ class Orchestrator:
                 if self.stages.get("qa"):
                     success, qa_output = self.script_qa.act(path)
                     self.history.append(
-                        {"role": "script_qa", "content": qa_output}
+                        {
+                            "role": "script_qa",
+                            "content": qa_output,
+                            "success": success,
+                        }
                     )
 
                 if self.stages.get("simulate"):


### PR DESCRIPTION
## Summary
- store script QA success flag in orchestrator history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684651694b78832396f453678d47690d