### PR TITLE
Refactor orchestrator evaluation retry

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -146,6 +146,10 @@ class Orchestrator:
                     self.history.append({"role": "judge_panel", "content": status})
                 if result.get("success") and approved:
                     break
+                # retry same goal on failure or rejection
+                self.leader.step -= 1
+                prev_plan = ""
+                continue
 
         return self.history
 


### PR DESCRIPTION
## Summary
- ensure the orchestrator retries planning when evaluation fails or the judge panel rejects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846539bbf2c8323a89ba8a7aedb9140