### PR TITLE
Implement Planner-Scientist iteration loop

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -74,6 +74,23 @@ class Orchestrator:
                 plan_prompt = f"You are Planner. Devise a brief plan for: {goal}"
                 plan = self.chat(plan_prompt).content
                 self.history.append({"role": "planner", "content": plan})
+
+                # Allow Planner and Scientist to refine the plan through
+                # a short back-and-forth before any research begins.
+                exchange_counter = 0
+                while exchange_counter < 3:
+                    sci_prompt = (
+                        f"You are Scientist. Review the plan and provide feedback: {plan}"
+                    )
+                    sci_msg = self.chat(sci_prompt).content
+                    self.history.append({"role": "scientist", "content": sci_msg})
+                    plan_prompt = (
+                        "You are Planner. Update the plan considering this feedback: "
+                        f"{sci_msg}"
+                    )
+                    plan = self.chat(plan_prompt).content
+                    self.history.append({"role": "planner", "content": plan})
+                    exchange_counter += 1
             else:
                 plan = prev_plan
 

--- a/tests/test_planner_scientist_loop.py
+++ b/tests/test_planner_scientist_loop.py
@@ -1,0 +1,52 @@
+import types
+from pathlib import Path
+import agents.orchestrator as orchestrator_mod
+import agents.researcher as researcher_mod
+import tsce_agent_demo.tsce_chat as tsce_chat_mod
+import agents.base_agent as base_agent_mod
+
+class DummyChat:
+    def __call__(self, messages):
+        if isinstance(messages, list):
+            content = messages[-1]["content"]
+        else:
+            content = messages
+        return types.SimpleNamespace(content=content)
+
+class DummyResearcher:
+    def __init__(self, *args, **kwargs):
+        self.history = []
+    def search(self, query):
+        return "data"
+    def send_message(self, message):
+        return message
+    def write_file(self, path, content):
+        Path(path).write_text(content)
+        return "ok"
+    def create_file(self, path, content=""):
+        Path(path).write_text(content)
+        return "ok"
+
+
+def test_planner_scientist_exchange(tmp_path, monkeypatch):
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
+    monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
+
+    orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
+    orch.drop_stage("script")
+    orch.drop_stage("qa")
+    orch.drop_stage("simulate")
+    orch.drop_stage("evaluate")
+    orch.drop_stage("judge")
+
+    history = orch.run()
+    roles = [m["role"] for m in history]
+    first_research = roles.index("researcher")
+    pre_research = roles[:first_research]
+    assert pre_research.count("planner") == 4
+    assert pre_research.count("scientist") >= 3


### PR DESCRIPTION
## Summary
- refine orchestration to include 3 exchanges between Planner and Scientist before calling Researcher
- add regression test verifying the new conversation loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465eb1a5848323b862928449f74dc6