### PR TITLE
Silence planner during active research

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ for step in history:
 ```
 Logs are saved under ``logs/`` by default; set ``LOG_DIR`` in your ``.env`` to change this.
 
-When a stage emits the ``TERMINATE`` token, the orchestrator now disables the planner with
-``drop_stage('planner')``. The planner is automatically reactivated for each new goal so repeated
-planning doesn't override ongoing research.
+When a stage emits the ``TERMINATE`` token, the orchestrator disables the planner with
+``drop_stage('planner')``. Planner messages only appear when ``self.stages["research"]``
+is inactive, so drop the research stage when you want planning to resume.
 
 The final stage now invokes a nine-member ``JudgePanel``. All judges must approve
 the evaluator's summary for the run to conclude.

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -64,13 +64,14 @@ class Orchestrator:
 
         while True:
             goal = self.leader.act()
-            # Reactivate planner when a new goal starts
-            self.activate_stage("planner")
+            # Reactivate planner for a new goal only when research is inactive
+            if not self.stages.get("research"):
+                self.activate_stage("planner")
             self.history.append({"role": "leader", "content": goal})
             if "terminate" in goal.lower():
                 break
 
-            if self.stages.get("planner"):
+            if self.stages.get("planner") and not self.stages.get("research"):
                 plan_prompt = f"You are Planner. Devise a brief plan for: {goal}"
                 plan = self.chat(plan_prompt).content
                 self.history.append({"role": "planner", "content": plan})

--- a/tests/test_planner_scientist_loop.py
+++ b/tests/test_planner_scientist_loop.py
@@ -43,10 +43,34 @@ def test_planner_scientist_exchange(tmp_path, monkeypatch):
     orch.drop_stage("simulate")
     orch.drop_stage("evaluate")
     orch.drop_stage("judge")
+    orch.drop_stage("research")  # enable planner messages
+
+    history = orch.run()
+    roles = [m["role"] for m in history]
+    first_research = roles.index("researcher") if "researcher" in roles else len(roles)
+    pre_research = roles[:first_research]
+    assert pre_research.count("planner") == 4
+    assert pre_research.count("scientist") >= 3
+
+
+def test_planner_silent_with_research_active(tmp_path, monkeypatch):
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
+    monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
+
+    orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
+    orch.drop_stage("script")
+    orch.drop_stage("qa")
+    orch.drop_stage("simulate")
+    orch.drop_stage("evaluate")
+    orch.drop_stage("judge")
 
     history = orch.run()
     roles = [m["role"] for m in history]
     first_research = roles.index("researcher")
     pre_research = roles[:first_research]
-    assert pre_research.count("planner") == 4
-    assert pre_research.count("scientist") >= 3
+    assert "planner" not in pre_research


### PR DESCRIPTION
## Summary
- only activate Planner when research stage is disabled
- update README to note planner silence while research is active
- tweak tests for new logic and add test ensuring Planner silence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684661744d8483239a5b92dbff16372d