### PR TITLE
Append research results

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -119,10 +119,13 @@ class Orchestrator:
                 data = self.researcher.search(goal)
                 self.history.append({"role": "researcher", "content": data})
                 plan = f"{plan}\n{data}"
-                self.researcher.create_file(
-                    os.path.join(self.output_dir, "research.txt"),
-                    data,
-                )
+                research_path = os.path.join(self.output_dir, "research.txt")
+                if os.path.exists(research_path):
+                    prev = self.researcher.read_file(research_path)
+                    new_content = prev + ("\n" if prev else "") + data
+                    self.researcher.write_file(research_path, new_content)
+                else:
+                    self.researcher.create_file(research_path, data)
                 token = record_agreed_hypothesis(
                     sci_hyp,
                     res_hyp,

--- a/tests/test_orchestrator_output.py
+++ b/tests/test_orchestrator_output.py
@@ -30,6 +30,8 @@ class DummyResearcher:
     def create_file(self, path, content=""):
         Path(path).write_text(content)
         return "ok"
+    def read_file(self, path):
+        return Path(path).read_text() if Path(path).exists() else ""
 
 
 def test_output_files_created(tmp_path, monkeypatch):
@@ -54,3 +56,30 @@ def test_output_files_created(tmp_path, monkeypatch):
     assert (tmp_path / "hypothesis").is_dir()
     assert (tmp_path / "hypothesis" / "leading_hypothesis.txt").exists()
     assert (tmp_path / "research.txt").exists()
+
+
+def test_research_file_appends(tmp_path, monkeypatch):
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
+    monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    orch = orchestrator_mod.Orchestrator([
+        "goal1",
+        "goal2",
+        "terminate",
+    ], model="test", output_dir=str(tmp_path))
+    orch.drop_stage("script")
+    orch.drop_stage("qa")
+    orch.drop_stage("simulate")
+    orch.drop_stage("evaluate")
+    orch.drop_stage("judge")
+
+    orch.run()
+
+    lines = (tmp_path / "research.txt").read_text().splitlines()
+    assert lines == ["data", "data"]

--- a/tests/test_planner_scientist_loop.py
+++ b/tests/test_planner_scientist_loop.py
@@ -26,6 +26,8 @@ class DummyResearcher:
     def create_file(self, path, content=""):
         Path(path).write_text(content)
         return "ok"
+    def read_file(self, path):
+        return Path(path).read_text() if Path(path).exists() else ""
 
 
 def test_planner_scientist_exchange(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- append new research findings to `research.txt` instead of overwriting
- add test covering append behavior
- expand DummyResearcher in tests to read files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f17ec59883239d00d73f6604a0f3