### PR TITLE
Ensure hypothesis recording doesn't halt run

### DIFF
--- a/agents/hypothesis.py
+++ b/agents/hypothesis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from .researcher import Researcher
 
 TERMINATE_TOKEN = "TERMINATE"
@@ -32,7 +33,13 @@ def record_agreed_hypothesis(
     """
     if sci_view.strip().lower() == res_view.strip().lower():
         agent = researcher or Researcher()
-        agent.write_file(path, sci_view)
+        dir_name = os.path.dirname(path)
+        if dir_name:
+            os.makedirs(dir_name, exist_ok=True)
+        if os.path.exists(path):
+            agent.write_file(path, sci_view)
+        else:
+            agent.create_file(path, sci_view)
         return TERMINATE_TOKEN
     return None
 

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -136,6 +136,8 @@ class Orchestrator:
                     self.history.append({"role": "hypothesis", "content": token})
                     # Planner is no longer needed once research begins
                     self.drop_stage("planner")
+                    # Mark hypothesis stage complete and proceed
+                    self.drop_stage("hypothesis")
 
             # --- Script writing -------------------------------------------
             if self.stages.get("script"):

--- a/tests/test_hypothesis_module.py
+++ b/tests/test_hypothesis_module.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import agents.hypothesis as hyp
+
+class FakeResearcher:
+    def __init__(self):
+        self.created = False
+        self.written = False
+    def create_file(self, path: str, content: str = ""):
+        self.created = True
+        Path(path).write_text(content)
+        return "ok"
+    def write_file(self, path: str, content: str):
+        self.written = True
+        Path(path).write_text(content)
+        return "ok"
+
+
+def test_record_agreed_hypothesis_creates_file(tmp_path):
+    p = tmp_path / "dir" / "lead.txt"
+    r = FakeResearcher()
+    token = hyp.record_agreed_hypothesis("A", "a", path=str(p), researcher=r)
+    assert token == hyp.TERMINATE_TOKEN
+    assert p.exists()
+    assert r.created
+    assert not r.written
+
+
+def test_record_agreed_hypothesis_overwrites(tmp_path):
+    p = tmp_path / "lead.txt"
+    p.write_text("old")
+    r = FakeResearcher()
+    token = hyp.record_agreed_hypothesis("B", "B", path=str(p), researcher=r)
+    assert token == hyp.TERMINATE_TOKEN
+    assert p.read_text() == "B"
+    assert r.written

--- a/tests/test_orchestrator_hypothesis_stage.py
+++ b/tests/test_orchestrator_hypothesis_stage.py
@@ -1,0 +1,54 @@
+import types
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agents.orchestrator as orchestrator_mod
+import agents.researcher as researcher_mod
+import tsce_agent_demo.tsce_chat as tsce_chat_mod
+import agents.base_agent as base_agent_mod
+
+class DummyChat:
+    def __call__(self, messages):
+        if isinstance(messages, list):
+            content = messages[-1]["content"]
+        else:
+            content = messages
+        return types.SimpleNamespace(content=content)
+
+class DummyResearcher:
+    def __init__(self, *args, **kwargs):
+        self.history = []
+    def search(self, query):
+        return "data"
+    def send_message(self, message):
+        return message
+    def write_file(self, path, content):
+        Path(path).write_text(content)
+        return "ok"
+    def create_file(self, path, content=""):
+        Path(path).write_text(content)
+        return "ok"
+    def read_file(self, path):
+        return Path(path).read_text() if Path(path).exists() else ""
+
+def test_hypothesis_stage_deactivated(tmp_path, monkeypatch):
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
+    monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
+    orch.drop_stage("script")
+    orch.drop_stage("qa")
+    orch.drop_stage("simulate")
+    orch.drop_stage("evaluate")
+    orch.drop_stage("judge")
+
+    orch.run()
+
+    assert not orch.stages["hypothesis"]


### PR DESCRIPTION
## Summary
- fix `record_agreed_hypothesis` to create or overwrite the file in the given directory
- deactivate hypothesis stage once the hypothesis is recorded
- add regression tests for hypothesis file creation and stage handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f312b6a4832396e9bc54f9a315f9