### PR TITLE
Implement Simulator log management

### DIFF
--- a/agents/simulator.py
+++ b/agents/simulator.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 import sys
 import time
+import shutil
 
 from .base_agent import BaseAgent
 
@@ -48,8 +49,10 @@ def run_simulation(path: str) -> str:
 class Simulator(BaseAgent):
     """Execute Python scripts and record the output."""
 
-    def __init__(self, *, log_dir: str | None = None) -> None:
+    def __init__(self, *, log_dir: str | None = None, output_dir: str = "results") -> None:
         super().__init__(name="Simulator", log_dir=log_dir)
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(exist_ok=True)
 
     def send_message(self, message: str) -> str:  # pragma: no cover
         return self.act(message)
@@ -57,7 +60,27 @@ class Simulator(BaseAgent):
     # ------------------------------------------------------------------
     def act(self, path: str) -> str:
         """Run ``path`` and return the log file location."""
-        return run_simulation(path)
+        return self.run_simulation(path)
+
+    # ------------------------------------------------------------------
+    def run_simulation(self, path: str) -> str:
+        """Run ``path`` and store the log in ``self.output_dir``.
+
+        The log file path is appended to ``self.history`` and returned.
+        """
+        original_log = run_simulation(path)
+        dest = self.output_dir / Path(original_log).name
+        try:
+            shutil.move(original_log, dest)
+        except Exception:
+            shutil.copy(original_log, dest)
+            try:
+                Path(original_log).unlink()
+            except FileNotFoundError:  # pragma: no cover - cleanup
+                pass
+        log_path = str(dest)
+        self.history.append(log_path)
+        return log_path
 
 
 __all__ = ["Simulator", "run_simulation"]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import agents.simulator as simulator_mod
+import agents.base_agent as base_agent_mod
+import tsce_agent_demo.tsce_chat as tsce_chat_mod
+
+
+class DummyChat:
+    def __call__(self, messages):
+        return type("R", (), {"content": "ok"})()
+
+
+def test_run_simulation_moves_log(tmp_path, monkeypatch):
+    script = tmp_path / "hello.py"
+    script.write_text('print("hi")')
+
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    sim = simulator_mod.Simulator(output_dir=str(tmp_path))
+    log_path = sim.run_simulation(str(script))
+
+    # log path returned and exists under output_dir
+    assert Path(log_path).exists()
+    assert Path(log_path).parent == sim.output_dir
+
+    # history records the log location
+    assert sim.history[-1] == log_path
+
+    # original results directory should not contain the log
+    assert not (Path("results") / Path(log_path).name).exists()


### PR DESCRIPTION
## Summary
- add optional `output_dir` to `Simulator`
- move simulation logs to `output_dir` and track location in agent history
- provide `Simulator.run_simulation` instance method
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f8506a208323910c683cf43b67b7