### PR TITLE
Write simulator log summary file

### DIFF
--- a/agents/evaluator.py
+++ b/agents/evaluator.py
@@ -75,7 +75,13 @@ class Evaluator(BaseAgent):
         success = (return_code == 0) and not stderr_lines
         summary = f"{path.name}: {'success' if success else 'failure'} (rc={return_code})"
 
-        summary_path = path.with_suffix(path.suffix + ".summary")
+        # Write a human‑readable summary next to the log file but without the
+        # timestamp that ``run_simulation`` adds to the log name.  The summary
+        # file uses the original script name with a ``.summary`` extension.
+        stem = path.stem
+        if "_" in stem:
+            stem = stem.rsplit("_", 1)[0]
+        summary_path = path.with_name(f"{stem}.summary")
         summary_path.write_text(summary + "\n", encoding="utf-8")
 
         return {

--- a/tests/test_evaluator_log_summary.py
+++ b/tests/test_evaluator_log_summary.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import agents.evaluator as evaluator_mod
+import agents.base_agent as base_agent_mod
+import tsce_agent_demo.tsce_chat as tsce_chat_mod
+
+
+def create_log(tmp_path, name, rc=0, stderr=None):
+    log_file = tmp_path / name
+    lines = ["output"]
+    if stderr:
+        lines.append("--- stderr ---")
+        lines.extend(stderr)
+    lines.append(f"--- return code: {rc} ---")
+    log_file.write_text("\n".join(lines), encoding="utf-8")
+    return log_file
+
+
+class DummyChat:
+    def __call__(self, messages):
+        return type("R", (), {"content": "ok"})()
+
+
+def test_summary_written_in_output_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+
+    log = create_log(tmp_path, "test_script_2024.log", rc=1, stderr=["err"])
+    ev = evaluator_mod.Evaluator(results_dir=tmp_path)
+    result = ev.parse_simulator_log(str(log))
+    summary_path = Path(result["summary_file"])
+    assert summary_path.exists()
+    assert summary_path.read_text().strip() == f"{log.name}: failure (rc=1)"
+    assert summary_path.name == "test_script.summary"
+    assert summary_path.parent == tmp_path


### PR DESCRIPTION
## Summary
- record log summaries by original script name in Evaluator
- test that the log summary file is created alongside simulator logs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fabdef1083239e434c7f4dbdcbee