### PR TITLE
Add orchestrator retry and script file tests

### DIFF
--- a/tests/test_evaluator_log_summary.py
+++ b/tests/test_evaluator_log_summary.py
@@ -1,4 +1,8 @@
 from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import agents.evaluator as evaluator_mod
 import agents.base_agent as base_agent_mod
 import tsce_agent_demo.tsce_chat as tsce_chat_mod

--- a/tests/test_orchestrator_judge_loop.py
+++ b/tests/test_orchestrator_judge_loop.py
@@ -1,0 +1,103 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import agents.orchestrator as orchestrator_mod
+import agents.researcher as researcher_mod
+import tsce_agent_demo.tsce_chat as tsce_chat_mod
+import agents.base_agent as base_agent_mod
+
+class DummyChat:
+    def __call__(self, messages):
+        if isinstance(messages, list):
+            content = messages[-1]["content"]
+        else:
+            content = messages
+        return types.SimpleNamespace(content=content)
+
+class DummyResearcher:
+    def __init__(self, *args, **kwargs):
+        self.history = []
+    def search(self, query):
+        return "data"
+    def send_message(self, message):
+        return message
+    def write_file(self, path, content):
+        Path(path).write_text(content)
+        return "ok"
+    def create_file(self, path, content=""):
+        Path(path).write_text(content)
+        return "ok"
+    def read_file(self, path):
+        return Path(path).read_text() if Path(path).exists() else ""
+
+class DummyEvaluator:
+    def __init__(self, *args, **kwargs):
+        self.calls = 0
+    def act(self):
+        self.calls += 1
+        return {"summary": "ok", "success": True}
+
+class DummyJudgePanel:
+    def __init__(self):
+        self.calls = 0
+    def vote(self, transcript):
+        self.calls += 1
+        return self.calls > 1
+
+
+def test_script_files_have_unique_names_and_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
+    monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    orch = orchestrator_mod.Orchestrator([
+        "goal1",
+        "goal2",
+        "terminate",
+    ], model="test", output_dir=str(tmp_path))
+    orch.drop_stage("qa")
+    orch.drop_stage("simulate")
+    orch.drop_stage("evaluate")
+    orch.drop_stage("judge")
+
+    orch.run()
+
+    scripts = sorted((tmp_path / "hypothesis").glob("test_hypothesis_*.py"))
+    names = [s.name for s in scripts]
+    assert len(names) == 2
+    assert len(set(names)) == 2
+    for s in scripts:
+        assert s.read_text().startswith("# GOLDEN_THREAD:")
+
+
+def test_judge_rejection_causes_retry(tmp_path, monkeypatch):
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
+    monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
+    monkeypatch.setattr(orchestrator_mod, "Evaluator", DummyEvaluator)
+    monkeypatch.setattr(orchestrator_mod, "JudgePanel", DummyJudgePanel)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
+    orch.drop_stage("qa")
+    orch.drop_stage("simulate")
+
+    history = orch.run()
+
+    judge_votes = [m for m in history if m.get("role") == "judge_panel"]
+    assert len(judge_votes) == 2
+    scripts = sorted((tmp_path / "hypothesis").glob("test_hypothesis_*.py"))
+    assert len(scripts) == 2
+    assert scripts[0].name != scripts[1].name


### PR DESCRIPTION
## Summary
- ensure evaluator tests find local modules
- test that scripts written by the orchestrator have unique names and include the golden thread marker
- verify the orchestrator retries when the judge panel rejects a result

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470f821a148323b9257df78051e9c9