### PR TITLE
Use unanimous judge panel

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -209,14 +209,14 @@ class Orchestrator:
             if self.stages.get("evaluate"):
                 result = self.evaluator.act()
                 self.history.append({"role": "evaluator", "content": result["summary"]})
-                approved = True
+
                 if self.stages.get("judge"):
-                    approved = self.judge_panel.vote(result["summary"])
-                    status = "approved" if approved else "rejected"
-                    self.history.append({"role": "judge_panel", "content": status})
-                if result.get("success") and approved:
+                    self.judge_panel.vote_until_unanimous(result["summary"])
+                    self.history.append({"role": "judge_panel", "content": "approved"})
+
+                if result.get("success"):
                     break
-                # retry same goal on failure or rejection
+                # retry same goal only when the evaluator fails
                 self.leader.step -= 1
                 prev_plan = ""
                 continue

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -10,6 +10,6 @@ This document explains the long form workflow implemented by the `Orchestrator`.
 6. **ScriptWriter** – generates an executable Python script. Files are stored under `output/hypothesis/`.
 7. **ScriptQA** – optional lint / unit test pass over the generated script.
 8. **Simulator** – runs the script and saves a log file. The **Evaluator** parses this log and creates a summary report.
-9. **JudgePanel** – nine independent Judge agents vote on the evaluator’s summary. The Orchestrator only finishes when all judges vote `YES`.
+9. **JudgePanel** – nine independent Judge agents review the evaluator’s summary. The orchestrator calls `vote_until_unanimous()` so execution waits until every judge approves. Only a failed evaluation triggers a retry.
 
 The pipeline can drop or reactivate stages via `drop_stage()` or `activate_stage()` on the orchestrator instance.


### PR DESCRIPTION
## Summary
- adopt `JudgePanel.vote_until_unanimous()` during evaluation
- only retry a goal when evaluation fails
- update pipeline docs
- adjust tests for unanimous judge behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473f678aa48323a76e37777cf53558