### PR TITLE
Support storing summary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__/
 # macOS system files
 .DS_Store
 
-results/
+results/*
+!results/README.md

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -202,8 +202,10 @@ class Orchestrator:
                 if self.stages.get("simulate"):
                     log_path = self.simulator.act(path)
                     self.history.append({"role": "simulator", "content": log_path})
-                    sim_result = self.evaluator.parse_simulator_log(log_path)
-                    self.history.append({"role": "evaluator", "content": sim_result["summary"]})
+                    sim_result = self.evaluator.parse_simulator_log(
+                        log_path, dest_dir=self.output_dir
+                    )
+                    self.history.append({"role": "evaluator", "content": sim_result["summary_file"]})
 
             # --- Evaluation -------------------------------------------------
             if self.stages.get("evaluate"):

--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,6 @@
+The `results/` directory stores simulation artifacts generated during tests and orchestrator runs.
+
+* `*.log` files contain raw stdout/stderr produced by executed Python scripts.
+* `*.summary` files record whether the run succeeded and are safe to share.
+
+When used with the `Orchestrator`, summaries are copied here so the latest run outputs are easy to locate.

--- a/tests/test_evaluator_log_summary.py
+++ b/tests/test_evaluator_log_summary.py
@@ -30,10 +30,26 @@ def test_summary_written_in_output_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
 
     log = create_log(tmp_path, "test_script_2024.log", rc=1, stderr=["err"])
+    dest_dir = tmp_path / "out"
     ev = evaluator_mod.Evaluator(results_dir=tmp_path)
-    result = ev.parse_simulator_log(str(log))
+    result = ev.parse_simulator_log(str(log), dest_dir=dest_dir)
     summary_path = Path(result["summary_file"])
     assert summary_path.exists()
     assert summary_path.read_text().strip() == f"{log.name}: failure (rc=1)"
     assert summary_path.name == "test_script.summary"
+    assert summary_path.parent == dest_dir
+    assert not (tmp_path / "test_script.summary").exists()
+
+
+def test_summary_written_next_to_log_by_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+
+    log = create_log(tmp_path, "test_script_2025.log", rc=0)
+    ev = evaluator_mod.Evaluator(results_dir=tmp_path)
+    result = ev.parse_simulator_log(str(log))
+    summary_path = Path(result["summary_file"])
+    assert summary_path.exists()
     assert summary_path.parent == tmp_path
+


### PR DESCRIPTION
## Summary
- extend `Evaluator.parse_simulator_log` with `dest_dir` option and move summary files there
- record evaluator summary path in `Orchestrator`
- document simulator results in new `results/README.md`
- allow tracked README in results folder
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684740f85ba88323aa55c4e625867f33