### PR TITLE
Handle list-based search results

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -147,7 +147,10 @@ class Orchestrator:
                     data_parts.append(output)
 
                 if not data_parts:
-                    data_parts.append(self.researcher.search(goal))
+                    search_results = self.researcher.search(goal)
+                    if isinstance(search_results, list):
+                        search_results = "\n".join(search_results)
+                    data_parts.append(search_results)
 
                 data = "\n".join(data_parts)
                 plan = f"{plan}\n{data}" if data else plan


### PR DESCRIPTION
## Summary
- join list-based search results in `Orchestrator.run`
- extend orchestrator research tests for search result lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475cb8020c8323b395e6c53722176a