### PR TITLE
Fix results path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Intuition: Imagine you ask a model, “Summarize this 1,000-word legal brief.”
 | `tsce_agent_demo/` | Harness & task sets that produced the results below. |
 | `tsce_agent_demo/tsce_agent_test.py` | Baseline vs TSCE, prints both answers, writes `report.json`. |
 | `tsce_agent_demo/tsce_chat.py` | Main TSCE wheel |
-| `tsce_agent_demo/results/` | Entropy, KL, cosine-violin plots ready to share. |
+| `results/` | Entropy, KL, cosine-violin plots ready to share. |
 | `tsce_agent_demo/run_orchestrator.py` | Command-line interface for the pipeline |
 | `tsce_agent_demo/inspect_tsce_layers.py` | Layer variance tool using transformer-lens |
 | `tsce_agent_demo/tsce_heval_test.py` | Evaluate the HaluEval benchmark |
@@ -282,7 +282,7 @@ Intuition: Imagine you ask a model, “Summarize this 1,000-word legal brief.”
 | `tsce_agent_demo/` | Harness & task sets that produced the results below. |
 | `tsce_agent_demo/tsce_agent_test.py` | Baseline vs TSCE, prints both answers, writes `report.json`. |
 | `tsce_agent_demo/tsce_chat.py` | Main TSCE wheel |
-| `tsce_agent_demo/results/` | Entropy, KL, cosine-violin plots ready to share. |
+| `results/` | Entropy, KL, cosine-violin plots ready to share. |
 | `tsce_agent_demo/run_orchestrator.py` | Command-line interface for the pipeline |
 | `tsce_agent_demo/inspect_tsce_layers.py` | Layer variance tool using transformer-lens |
 | `tsce_agent_demo/tsce_heval_test.py` | Evaluate the HaluEval benchmark |

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -29,7 +29,9 @@ class Orchestrator:
         self.script_writer = ScriptWriter(log_dir=log_dir)
         self.script_qa = ScriptQA(log_dir=log_dir)
         self.simulator = Simulator(log_dir=log_dir)
-        self.results_dir = "tsce_agent_demo/results"
+        # Store all results in the project’s top‑level ``results`` directory
+        # so that no artifacts end up under ``tsce_agent_demo``.
+        self.results_dir = "results"
         self.evaluator = Evaluator(results_dir=self.results_dir, log_dir=log_dir)
         self.judge_panel = JudgePanel()
         self.output_dir = output_dir


### PR DESCRIPTION
## Summary
- write evaluator results under `results/` at the repository root
- update docs to mention the correct results directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847a564bb548323834c7e494b532a07