### PR TITLE
Decouple orchestrator evaluator from summary_stats.md

### DIFF
--- a/agents/evaluator.py
+++ b/agents/evaluator.py
@@ -19,34 +19,19 @@ class Evaluator(BaseAgent):
 
     # ------------------------------------------------------------------
     def _parse_summary(self) -> Dict[str, Any]:
-        """Return baseline/TSCE pass rates from summary_stats.md."""
-        summary_file = self.results_dir / "summary_stats.md"
-        if not summary_file.exists():
-            raise FileNotFoundError(f"{summary_file} not found")
+        """Return the latest ``.summary`` result."""
+        summaries = sorted(self.results_dir.glob("*.summary"))
+        if not summaries:
+            raise FileNotFoundError(f"No summary files found in {self.results_dir}")
 
-        baseline_pass = baseline_total = 0
-        tsce_pass = tsce_total = 0
-        with summary_file.open(encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith("| baseline"):
-                    parts = [p.strip() for p in line.split("|") if p.strip()]
-                    if len(parts) >= 2 and "/" in parts[1]:
-                        baseline_pass, baseline_total = map(int, parts[1].split("/", 1))
-                elif line.startswith("| tsce"):
-                    parts = [p.strip() for p in line.split("|") if p.strip()]
-                    if len(parts) >= 2 and "/" in parts[1]:
-                        tsce_pass, tsce_total = map(int, parts[1].split("/", 1))
+        summary_file = summaries[-1]
+        summary = summary_file.read_text(encoding="utf-8").strip()
+        success = summary.startswith(summary_file.stem) and "success" in summary
 
-        baseline_rate = baseline_pass / baseline_total if baseline_total else 0.0
-        tsce_rate = tsce_pass / tsce_total if tsce_total else 0.0
         return {
-            "baseline_pass": baseline_pass,
-            "baseline_total": baseline_total,
-            "baseline_rate": baseline_rate,
-            "tsce_pass": tsce_pass,
-            "tsce_total": tsce_total,
-            "tsce_rate": tsce_rate,
+            "summary": summary,
+            "success": success,
+            "summary_file": str(summary_file),
         }
 
     # ------------------------------------------------------------------
@@ -122,16 +107,8 @@ class Evaluator(BaseAgent):
 
     # ------------------------------------------------------------------
     def act(self) -> Dict[str, Any]:
-        """Summarize the run and return a success flag."""
-        data = self._parse_summary()
-        improved = data["tsce_rate"] > data["baseline_rate"]
-        summary = (
-            f"Baseline {data['baseline_pass']}/{data['baseline_total']} "
-            f"({data['baseline_rate']:.1%}); "
-            f"TSCE {data['tsce_pass']}/{data['tsce_total']} "
-            f"({data['tsce_rate']:.1%})."
-        )
-        return {"summary": summary, "success": improved}
+        """Return the latest summary and success flag."""
+        return self._parse_summary()
 
 
 __all__ = ["Evaluator"]

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -203,7 +203,7 @@ class Orchestrator:
                     log_path = self.simulator.act(path)
                     self.history.append({"role": "simulator", "content": log_path})
                     sim_result = self.evaluator.parse_simulator_log(
-                        log_path, dest_dir=self.output_dir
+                        log_path, dest_dir=self.results_dir
                     )
                     self.history.append({"role": "evaluator", "content": sim_result["summary_file"]})
 


### PR DESCRIPTION
## Summary
- adjust `Evaluator` to read the latest `.summary` file instead of `summary_stats.md`
- update `Orchestrator` so simulator summaries are saved under the `results/` directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a7d4753483238587c7a95c5abb33