### PR TITLE
Implement structured response format

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import List
 
-from .base_agent import BaseAgent
+from .base_agent import BaseAgent, compose_sections
 
 
 class Planner(BaseAgent):
@@ -28,4 +28,5 @@ class Planner(BaseAgent):
 
     def send_message(self, message: str) -> str:  # pragma: no cover
         self.context = message
-        return "\n".join(self.act())
+        output = "\n".join(self.act())
+        return compose_sections("", "", output)

--- a/agents/researcher.py
+++ b/agents/researcher.py
@@ -15,6 +15,7 @@ from tools import (
 )
 
 from .base import BaseAgent
+from .base_agent import compose_sections
 
 class Researcher(BaseAgent):
     """Agent capable of searching the web and reading/writing files."""
@@ -48,9 +49,10 @@ class Researcher(BaseAgent):
     def send_message(self, message: str) -> str:
         """Send ``message`` to the model and return the reply."""
         reply = self.chat(message)
+        formatted = compose_sections("", "", reply)
         self.history.append(message)
-        self.history.append(reply)
-        return reply
+        self.history.append(formatted)
+        return formatted
 
     # Convenience wrappers -------------------------------------------------
     def search(self, query: str) -> str:

--- a/agents/script_qa.py
+++ b/agents/script_qa.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 from typing import Tuple
 
-from .base_agent import BaseAgent
+from .base_agent import BaseAgent, compose_sections
 
 
 def run_tests(path: str | os.PathLike) -> Tuple[bool, str]:
@@ -50,7 +50,8 @@ class ScriptQA(BaseAgent):
 
     def send_message(self, message: str) -> str:  # pragma: no cover
         success, output = self.act(message)
-        return output if success else output
+        formatted = compose_sections("", "", output)
+        return formatted
 
     # ------------------------------------------------------------------
     def act(self, path: str | os.PathLike) -> Tuple[bool, str]:

--- a/agents/simulator.py
+++ b/agents/simulator.py
@@ -5,7 +5,7 @@ import sys
 import time
 import shutil
 
-from .base_agent import BaseAgent
+from .base_agent import BaseAgent, compose_sections
 
 
 def run_simulation(path: str) -> str:
@@ -55,7 +55,8 @@ class Simulator(BaseAgent):
         self.output_dir.mkdir(exist_ok=True)
 
     def send_message(self, message: str) -> str:  # pragma: no cover
-        return self.act(message)
+        output = self.act(message)
+        return compose_sections("", "", output)
 
     # ------------------------------------------------------------------
     def act(self, path: str) -> str:

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -31,14 +31,16 @@ def test_send_message_history(monkeypatch):
     monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: simple)
     def patched_send(self, m):
         reply = researcher_mod.Researcher.chat(self, m)
+        formatted = base_agent_mod.compose_sections("", "", reply)
         self.history.append(m)
-        self.history.append(reply)
-        return reply
+        self.history.append(formatted)
+        return formatted
     monkeypatch.setattr(researcher_mod.Researcher, "send_message", patched_send)
     r = researcher_mod.Researcher(model="test-model")
     result = r.send_message("hello")
-    assert result == "ack:hello"
-    assert r.history[-2:] == ["hello", "ack:hello"]
+    expected = base_agent_mod.compose_sections("", "", "ack:hello")
+    assert result == expected
+    assert r.history[-2:] == ["hello", expected]
     assert dummy.called_with[0]["role"] == "system"
 
 def test_env_model(monkeypatch):
@@ -50,9 +52,10 @@ def test_env_model(monkeypatch):
     monkeypatch.setattr(base_agent_mod, "TSCEChat", fake_chat)
     def patched_send(self, m):
         reply = researcher_mod.Researcher.chat(self, m)
+        formatted = base_agent_mod.compose_sections("", "", reply)
         self.history.append(m)
-        self.history.append(reply)
-        return reply
+        self.history.append(formatted)
+        return formatted
     monkeypatch.setattr(researcher_mod.Researcher, "send_message", patched_send)
     monkeypatch.setenv("MODEL_NAME", "env-model")
     r = researcher_mod.Researcher()

--- a/tests/test_scientist_researcher.py
+++ b/tests/test_scientist_researcher.py
@@ -2,6 +2,7 @@ import types
 
 from agents.scientist import Scientist
 from agents.base_agent import BaseAgent
+import agents.base_agent as base_agent_mod
 
 class FakeChat:
     def __init__(self):
@@ -20,7 +21,12 @@ def test_request_information_uses_researcher_and_logs():
     sci = Scientist(name="Scientist", chat=chat)
     res = DummyResearcher(name="Researcher", chat=chat)
     reply = sci.request_information(res, "planet mass")
-    assert reply == "reply:Research the following and report back: planet mass"
+    expected = base_agent_mod.compose_sections(
+        "",
+        "",
+        "reply:Research the following and report back: planet mass",
+    )
+    assert reply == expected
     assert sci.history[0]["content"] == "planet mass" or "Research" in sci.history[0]["content"]
     assert res.history
 
@@ -29,6 +35,7 @@ def test_direct_researcher_forwards_instructions():
     sci = Scientist(name="Scientist", chat=chat)
     res = DummyResearcher(name="Researcher", chat=chat)
     reply = sci.direct_researcher(res, "Do thing A")
-    assert reply == "reply:Do thing A"
+    expected = base_agent_mod.compose_sections("", "", "reply:Do thing A")
+    assert reply == expected
     assert sci.history
     assert res.history


### PR DESCRIPTION
## Summary
- add helper functions to assemble/parse messages with *Thoughts*, *Critical Thinking* and *Speak* sections
- emit responses in this new format from `BaseAgent` and subclasses
- update Planner, Researcher, ScriptQA and Simulator
- adjust tests for the new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847be4aa5a48323a75b77f766d38297