### PR TITLE
Add generic tool interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ Additional utilities:
 * ``tsce_agent_demo/inspect_tsce_layers.py`` – analyse layer-wise variance on local models.
 * ``tsce_agent_demo/tsce_heval_test.py`` – run the HaluEval benchmark with TSCE.
 
+### Built-in Tools
+
+Agents may call helper utilities by returning a JSON object in the ``Speak`` section:
+
+```json
+{"tool": "google_search", "args": {"query": "python", "num_results": 2}}
+```
+
+Tool names:
+
+* ``google_search`` – quick Google result titles
+* ``web_scrape`` – fetch a web page and strip HTML
+* ``create_file`` – create a new text file
+* ``read_file`` – read a text file
+* ``edit_file`` – overwrite an existing file
+* ``delete_file`` – remove a file
+* ``run_script`` – execute a Python script
+
 ---
 
 ### Troubleshooting <a name="troubleshooting"></a>

--- a/tests/test_tool_integration.py
+++ b/tests/test_tool_integration.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import tools
+from agents.base_agent import BaseAgent, compose_sections
+import agents.base_agent as base_agent_mod
+import tsce_agent_demo.tsce_chat as tsce_chat_mod
+
+class DummyChat:
+    def __init__(self, reply):
+        self.reply = reply
+    def __call__(self, messages):
+        return types.SimpleNamespace(content=self.reply)
+
+class DummyAgent(BaseAgent):
+    pass
+
+
+def test_json_tool_call(monkeypatch):
+    class Dummy:
+        def __call__(self, query=""):
+            return "result"
+    monkeypatch.setitem(tools.TOOL_CLASSES, "dummy", Dummy)
+    reply = compose_sections("t", "c", '{"tool":"dummy","args":{"query":"x"}}')
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat(reply))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat(reply))
+    agent = DummyAgent("test")
+    output = agent.send_message("hi")
+    assert "result" in output

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,8 @@ from unittest.mock import mock_open
 import requests
 import subprocess
 import os
+import pytest
+import tools
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -16,6 +18,7 @@ from tools import (
     EditFileTool,
     DeleteFileTool,
     RunScriptTool,
+    use_tool,
 )
 
 
@@ -147,3 +150,17 @@ def test_run_script_missing(monkeypatch):
     tool = RunScriptTool()
     msg = tool("script.py")
     assert msg == "Error: script.py not found"
+
+
+def test_use_tool_dispatch(monkeypatch):
+    class Dummy:
+        def __call__(self, **kw):
+            return "ok"
+
+    monkeypatch.setitem(tools.__dict__["TOOL_CLASSES"], "dummy", Dummy)
+    assert use_tool("dummy") == "ok"
+
+
+def test_use_tool_unknown():
+    with pytest.raises(ValueError):
+        use_tool("nope")

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -16,6 +16,33 @@ from .file_edit import EditFileTool
 from .file_delete import DeleteFileTool
 from .run_script import RunScriptTool
 
+TOOL_CLASSES = {
+    "google_search": GoogleSearch,
+    "web_scrape": WebScrape,
+    "create_file": CreateFileTool,
+    "read_file": ReadFileTool,
+    "edit_file": EditFileTool,
+    "delete_file": DeleteFileTool,
+    "run_script": RunScriptTool,
+}
+
+
+def use_tool(name: str, args: dict | None = None):
+    """Instantiate and execute a tool by ``name`` with ``args``.
+
+    Parameters
+    ----------
+    name:
+        Tool identifier from ``TOOL_CLASSES``.
+    args:
+        Keyword arguments forwarded to the tool call.
+    """
+    cls = TOOL_CLASSES.get(name.lower())
+    if not cls:
+        raise ValueError(f"Unknown tool: {name}")
+    args = args or {}
+    return cls()(**args)
+
 __all__ = [
     "GoogleSearch",
     "WebScrape",
@@ -24,4 +51,5 @@ __all__ = [
     "EditFileTool",
     "DeleteFileTool",
     "RunScriptTool",
+    "use_tool",
 ]


### PR DESCRIPTION
## Summary
- allow agents to execute tools via a common `use_tool` function
- dispatch tool calls from `BaseAgent.send_message`
- document available tools with JSON examples
- test new helper and agent integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c16d4dc88323b07f4c430683fdd6