### PR TITLE
Update orchestrator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,26 +151,39 @@ streamlit run streamlit_chat.py
 
 ### Orchestrator Demo <a name="orchestrator-demo"></a>
 
-An extended workflow coordinates all agents in stages. Create an
-``Orchestrator`` with a list of goals and call ``run()``:
+The orchestrator now routes chat messages through each agent. Instantiate it
+with your goals and iterate over ``run()`` to inspect the conversation:
 
 ```python
 from agents import Orchestrator
 
 goals = ["Print hello world", "TERMINATE"]
-orc = Orchestrator(goals, log_dir="logs")  # logs conversations to logs/*.log
-history = orc.run()
-for step in history:
-    print(step["role"], step["content"])
+orc = Orchestrator(goals, log_dir="logs")
+for msg in orc.run():
+    print(msg["role"], msg["content"])
 ```
-Logs are saved under ``logs/`` by default; set ``LOG_DIR`` in your ``.env`` to change this.
+Logs are saved under ``logs/`` by default; set ``LOG_DIR`` in your ``.env`` to
+change this.
 
-When a stage emits the ``TERMINATE`` token, the orchestrator disables the planner
-automatically. The research stage starts only after the hypothesis is written, so
-planning resumes on the next goal without any manual ``drop_stage()`` calls.
+When the ``TERMINATE`` token appears, the planner and hypothesis stages are
+deactivated automatically. The remaining agents finish the job without any manual
+stage toggling.
 
-The final stage now invokes a nine-member ``JudgePanel``. All judges must approve
-the evaluator's summary for the run to conclude.
+Sample ``hello world`` session:
+
+```
+leader Print hello world
+planner Use Python's ``print``
+scientist Looks good
+hypothesis TERMINATE
+script_writer print("Hello, world!")
+simulator Hello, world!
+evaluator success
+judge_panel approved
+```
+
+The run concludes only when the nine-member ``JudgePanel`` unanimously approves
+the evaluator's summary.
 
 ### Pipeline Overview <a name="pipeline-overview"></a>
 
@@ -408,19 +421,18 @@ streamlit run streamlit_chat.py
 
 ### Orchestrator Demo <a name="orchestrator-demo"></a>
 
-Use the orchestrator to run each agent stage in sequence:
+Run all agents as a single chat session:
 
 ```python
 from agents import Orchestrator
 
 goals = ["Print hello world", "TERMINATE"]
 orc = Orchestrator(goals, log_dir="logs")
-orc.run()
+for msg in orc.run():
+    print(msg["role"], msg["content"])
 ```
-Logs are written to ``logs/`` by default.
-
-The run finishes only when the ``JudgePanel`` unanimously approves the final
-evaluation.
+Logs are written to ``logs/`` by default and the conversation stops only after
+the ``JudgePanel`` votes to approve the evaluation.
 
 ---
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,15 +1,40 @@
 # Multi-Stage Agent Pipeline
 
-This document explains the long form workflow implemented by the `Orchestrator`. Each stage is a distinct agent that feeds its output to the next.
+This document explains the long form workflow implemented by the `Orchestrator`.
+Each stage is a distinct agent that feeds its output to the next.
 
 1. **Leader** – pulls the next goal from the list.
 2. **Planner** – produces a step-by-step plan that the **Scientist** can inspect.
 3. **Scientist** – critiques and iteratively refines the plan with the Planner.
 4. **Researcher** – performs web or file searches to gather data for the plan.
-5. **Hypothesis** – Scientist and Researcher must agree on a written hypothesis. When they do, a `TERMINATE` token is written to disk, the planner stage is disabled and the research stage is activated.
-6. **ScriptWriter** – generates an executable Python script. Files are stored under `output/hypothesis/`.
+5. **Hypothesis** – Scientist and Researcher must agree on a written hypothesis.
+   When they do, a `TERMINATE` token is logged, the planner stage is disabled and
+   the research stage is activated.
+6. **ScriptWriter** – generates an executable Python script. Files are stored
+   under `output/hypothesis/`.
 7. **ScriptQA** – optional lint / unit test pass over the generated script.
-8. **Simulator** – runs the script and saves a log file. The **Evaluator** parses this log and creates a summary report.
-9. **JudgePanel** – nine independent Judge agents review the evaluator’s summary. The orchestrator calls `vote_until_unanimous()` so execution waits until every judge approves. Only a failed evaluation triggers a retry.
+8. **Simulator** – runs the script and saves a log file. The **Evaluator** parses
+   this log and creates a summary report.
+9. **JudgePanel** – nine independent Judge agents review the evaluator’s
+   summary. The orchestrator calls `vote_until_unanimous()` so execution waits
+   until every judge approves. Only a failed evaluation triggers a retry.
 
-The pipeline can drop or reactivate stages via `drop_stage()` or `activate_stage()` on the orchestrator instance.
+## Message Routing
+
+The orchestrator maintains a queue of ``Message`` objects. Each message records
+the sender, intended recipients and text. When ``run()`` starts the Leader's goal
+is queued. Agents process messages addressed to them and may append new messages
+for subsequent stages. This queue-driven approach ensures that every agent
+receives the latest context in order.
+
+If the hypothesis stage emits ``TERMINATE`` or the orchestrator detects a trivial
+task such as printing ``hello world``, planning is skipped and later stages run
+immediately. This short‑circuit behaviour lets simple prompts finish without any
+manual stage management.
+
+## Legacy Manual Control
+
+Older versions allowed you to drop or reactivate stages via ``drop_stage()`` and
+``activate_stage()`` on the orchestrator. These methods remain for backward
+compatibility but are rarely needed now that routing and short‑circuit logic are
+automatic.


### PR DESCRIPTION
## Summary
- document new chat-based workflow
- show hello world session output
- explain queue routing and short-circuit logic
- move drop_stage info to legacy section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848436b1b7c83238da7b7afa0a8f618