### PR TITLE
Add run_legacy wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ for msg in orc.run():
 Logs are saved under ``logs/`` by default; set ``LOG_DIR`` in your ``.env`` to
 change this.
 
+Old scripts can still call ``run_legacy()`` to reproduce the original
+round-robin controller:
+
+```python
+history = orc.run_legacy()
+```
+
 When the ``TERMINATE`` token appears, the planner and hypothesis stages are
 deactivated automatically. The remaining agents finish the job without any manual
 stage toggling.
@@ -433,6 +440,12 @@ for msg in orc.run():
 ```
 Logs are written to ``logs/`` by default and the conversation stops only after
 the ``JudgePanel`` votes to approve the evaluation.
+
+For compatibility with earlier versions, invoke ``run_legacy()``:
+
+```python
+legacy_history = orc.run_legacy()
+```
 
 ---
 

--- a/tests/test_run_legacy.py
+++ b/tests/test_run_legacy.py
@@ -1,0 +1,31 @@
+import types
+
+import agents.orchestrator as orchestrator_mod
+import tsce_agent_demo.tsce_chat as tsce_chat_mod
+import agents.base_agent as base_agent_mod
+
+
+class DummyChat:
+    def __call__(self, messages):
+        if isinstance(messages, list):
+            content = messages[-1]["content"]
+        else:
+            content = messages
+        return types.SimpleNamespace(content=content)
+
+
+def _patch(monkeypatch):
+    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
+    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
+
+
+def test_run_legacy_round_robin(tmp_path, monkeypatch):
+    _patch(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
+    history = orch.run_legacy()
+    roles = [m["role"] for m in history]
+    assert roles == ["leader", "planner", "scientist", "leader"]


### PR DESCRIPTION
## Summary
- mark `drop_stage` and `activate_stage` docstrings as legacy helpers
- add `run_legacy()` wrapper to replicate the original round‑robin flow
- document `run_legacy()` usage in the README
- test that `run_legacy()` returns the expected history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484b6b9a308323be56c6d89b983567