### PR TITLE
Fix invalid escape warning in generated scripts

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -105,7 +105,7 @@ class Orchestrator:
             compile(script, "<string>", "exec")
         except SyntaxError:
             escaped = script.replace('"""', '\"\"\"')
-            script = f'"""\n{escaped}\n"""'
+            script = f'r"""\n{escaped}\n"""'
         return script
 
     # ------------------------------------------------------------------

--- a/tests/test_sanitize_script.py
+++ b/tests/test_sanitize_script.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from agents.orchestrator import Orchestrator
+
+
+def test_sanitize_script_uses_raw_prefix():
+    orch = object.__new__(Orchestrator)
+    bad_script = 'print("hi)'
+    sanitized = orch._sanitize_script(bad_script)
+    assert sanitized.startswith('r"""')
+    compile(sanitized, '<string>', 'exec')


### PR DESCRIPTION
## Summary
- avoid SyntaxWarning for invalid escape sequences when wrapping failing scripts
- test sanitize_script uses raw string docstring

## Testing
- `pytest -q`
- `pytest tests/test_sanitize_script.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68485d36a1dc8323bacffda12d61538c