### PR TITLE
Implement needs_code to gate script stage

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -78,6 +78,22 @@ class Orchestrator:
         """Return ``True`` if ``text`` indicates a trivial task."""
         return "hello world" in text.lower()
 
+    def needs_code(self, plan: str) -> bool:
+        """Return ``True`` if ``plan`` suggests writing or running code."""
+        lowered = plan.lower()
+        keywords = [
+            "code",
+            "script",
+            "python",
+            "execute",
+            "run",
+            "compute",
+            "calculate",
+            "fibonacci",
+            "factorial",
+        ]
+        return any(word in lowered for word in keywords)
+
     def drop_stage(self, stage: str) -> None:
         """Legacy helper to disable a processing stage.
 
@@ -245,7 +261,11 @@ class Orchestrator:
 
             elif sender == "researcher":
                 plan = content
-                if self.stages.get("script"):
+                need_code = self.needs_code(plan)
+                if not need_code:
+                    self.drop_stage("script")
+
+                if self.stages.get("script") and need_code:
                     script, gid = self.script_writer.act(plan)
                     script = self._sanitize_script(script)
                     self.history.append({"role": "script_writer", "content": script})

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -83,12 +83,12 @@ def test_queue_simple_goal(tmp_path, monkeypatch):
     _patch_all(monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
-    orch = orchestrator_mod.Orchestrator(["say hello world", "terminate"], model="test", output_dir=str(tmp_path))
+    orch = orchestrator_mod.Orchestrator(["tell me a joke", "terminate"], model="test", output_dir=str(tmp_path))
     history = orch.run()
     roles = [m["role"] for m in history]
     assert roles[-1] == "judge_panel"
     assert "final_qa" in roles
-    assert "researcher" not in roles
+    assert "researcher" in roles
     assert "script_writer" not in roles
     assert "simulator" not in roles
 

--- a/tests/test_orchestrator_judge_loop.py
+++ b/tests/test_orchestrator_judge_loop.py
@@ -62,11 +62,15 @@ def test_script_files_have_unique_names_and_marker(tmp_path, monkeypatch):
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
-    orch = orchestrator_mod.Orchestrator([
-        "goal1",
-        "goal2",
-        "terminate",
-    ], model="test", output_dir=str(tmp_path))
+    orch = orchestrator_mod.Orchestrator(
+        [
+            "compute fibonacci 2",
+            "compute factorial 3",
+            "terminate",
+        ],
+        model="test",
+        output_dir=str(tmp_path),
+    )
     orch.drop_stage("qa")
     orch.drop_stage("simulate")
     orch.drop_stage("evaluate")
@@ -94,7 +98,11 @@ def test_judge_rejection_causes_retry(tmp_path, monkeypatch):
     monkeypatch.setattr(orchestrator_mod, "JudgePanel", DummyJudgePanel)
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
-    orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
+    orch = orchestrator_mod.Orchestrator(
+        ["compute fibonacci 2", "terminate"],
+        model="test",
+        output_dir=str(tmp_path),
+    )
     orch.drop_stage("qa")
     orch.drop_stage("simulate")
 


### PR DESCRIPTION
## Summary
- add `needs_code()` helper for checking if a plan requires code
- skip script stage when no coding is needed
- update researcher flow to use the helper
- adjust message queue and judge loop tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684873d0606c8323a47d533e9b426a49