### PR TITLE
Add per-run output directories for Orchestrator

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -11,7 +11,8 @@ Each stage is a distinct agent that feeds its output to the next.
    When they do, a `TERMINATE` token is logged, the planner stage is disabled and
    the research stage is activated.
 6. **ScriptWriter** – generates an executable Python script. Files are stored
-   under `output/hypothesis/`.
+   under `output/run_<id>/hypothesis/` where `<id>` is a unique identifier for
+   each run.
 7. **ScriptQA** – optional lint / unit test pass over the generated script.
 8. **Simulator** – runs the script and saves a log file. The **Evaluator** parses
    this log and creates a summary report.

--- a/tests/test_orchestrator_judge_loop.py
+++ b/tests/test_orchestrator_judge_loop.py
@@ -78,7 +78,8 @@ def test_script_files_have_unique_names_and_marker(tmp_path, monkeypatch):
 
     orch.run()
 
-    scripts = sorted((tmp_path / "hypothesis").glob("test_hypothesis_*.py"))
+    run_path = Path(orch.output_dir)
+    scripts = sorted((run_path / "hypothesis").glob("test_hypothesis_*.py"))
     names = [s.name for s in scripts]
     assert len(names) == 2
     assert len(set(names)) == 2
@@ -113,7 +114,8 @@ def test_judge_rejection_causes_retry(tmp_path, monkeypatch):
     assert judge_votes[0]["content"] == "approved"
 
     # only one script because rejections no longer trigger a retry
-    scripts = sorted((tmp_path / "hypothesis").glob("test_hypothesis_*.py"))
+    run_path = Path(orch.output_dir)
+    scripts = sorted((run_path / "hypothesis").glob("test_hypothesis_*.py"))
     assert len(scripts) == 1
 
     # but the judge was polled until approval

--- a/tests/test_orchestrator_output.py
+++ b/tests/test_orchestrator_output.py
@@ -53,9 +53,10 @@ def test_output_files_created(tmp_path, monkeypatch):
 
     orch.run()
 
-    assert (tmp_path / "hypothesis").is_dir()
-    assert (tmp_path / "hypothesis" / "leading_hypothesis.txt").exists()
-    assert (tmp_path / "research.txt").exists()
+    run_path = Path(orch.output_dir)
+    assert (run_path / "hypothesis").is_dir()
+    assert (run_path / "hypothesis" / "leading_hypothesis.txt").exists()
+    assert (run_path / "research.txt").exists()
 
 
 def test_research_file_appends(tmp_path, monkeypatch):
@@ -81,7 +82,8 @@ def test_research_file_appends(tmp_path, monkeypatch):
 
     history = orch.run()
 
-    lines = (tmp_path / "research.txt").read_text().splitlines()
+    run_path = Path(orch.output_dir)
+    lines = (run_path / "research.txt").read_text().splitlines()
     assert lines == ["data"]
 
     roles = [m["role"] for m in history]

--- a/tests/test_orchestrator_research_tools.py
+++ b/tests/test_orchestrator_research_tools.py
@@ -89,7 +89,8 @@ def test_scientist_instructs_researcher(tmp_path, monkeypatch):
 
     orch.run()
 
-    lines = (tmp_path / "research.txt").read_text().splitlines()
+    run_path = Path(orch.output_dir)
+    lines = (run_path / "research.txt").read_text().splitlines()
     assert "scraped:http://example.com" in lines[0]
     assert "ran:tool.py" in lines[1]
 
@@ -112,6 +113,7 @@ def test_search_results_list_joined(tmp_path, monkeypatch):
 
     orch.run()
 
-    lines = (tmp_path / "research.txt").read_text().splitlines()
+    run_path = Path(orch.output_dir)
+    lines = (run_path / "research.txt").read_text().splitlines()
     assert lines == ["result1", "result2"]
 

--- a/tsce_agent_demo/run_orchestrator.py
+++ b/tsce_agent_demo/run_orchestrator.py
@@ -36,7 +36,7 @@ def main() -> None:
             return {k: _serialise(v) for k, v in item.items()}
         return item
 
-    out_path = os.path.join(args.output, "history.json")
+    out_path = os.path.join(orch.output_dir, "history.json")
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(_serialise(history), f, indent=2)
     print(f"Run complete. History saved to {out_path}")


### PR DESCRIPTION
## Summary
- give each Orchestrator run its own `run_<id>` directory
- keep evaluation summaries copied to the global `results/` folder
- save CLI history in the run directory
- update documentation and tests for the new layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684875bafc3c8323bef1bf231afa455a