### PR TITLE
Implement Scientist.execute_plan

### DIFF
--- a/tests/test_scientist_researcher.py
+++ b/tests/test_scientist_researcher.py
@@ -16,6 +16,30 @@ class FakeChat:
 class DummyResearcher(BaseAgent):
     pass
 
+
+class LoggingResearcher(BaseAgent):
+    """Researcher stub that records tool usage."""
+
+    def __init__(self, *a, **kw):
+        super().__init__(name="Researcher", *a, **kw)
+        self.calls = []
+
+    def search(self, query):
+        self.calls.append(("search", query))
+        return "s:" + query
+
+    def scrape(self, url):
+        self.calls.append(("scrape", url))
+        return "sc:" + url
+
+    def run_script(self, path):
+        self.calls.append(("run", path))
+        return "run:" + path
+
+    def send_message(self, message):
+        self.calls.append(("send_message", message))
+        return message
+
 def test_request_information_uses_researcher_and_logs():
     chat = FakeChat()
     sci = Scientist(name="Scientist", chat=chat)
@@ -39,3 +63,17 @@ def test_direct_researcher_forwards_instructions():
     assert reply == expected
     assert sci.history
     assert res.history
+
+
+def test_execute_plan_invokes_tools_and_logs():
+    chat = FakeChat()
+    sci = Scientist(name="Scientist", chat=chat)
+    res = LoggingResearcher(chat=chat)
+
+    plan = """Step 1: search planets\nStep 2: scrape http://example.com\nStep 3: run script.py"""
+    sci.execute_plan(plan, res)
+
+    assert ("search", "planets") in res.calls
+    assert ("scrape", "http://example.com") in res.calls
+    assert ("run", "script.py") in res.calls
+    assert sci.history


### PR DESCRIPTION
## Summary
- add execute_plan method to Scientist for handling numbered plan steps
- log tool usage in Scientist history
- cover execute_plan with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bee510e48323b33d2410e4d968b1