### PR TITLE
Add literature search tools

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -15,6 +15,8 @@ from .file_read import ReadFileTool
 from .file_edit import EditFileTool
 from .file_delete import DeleteFileTool
 from .run_script import RunScriptTool
+from .literature_search.arxiv import ArxivSearch
+from .literature_search.pubmed import PubMedSearch
 
 TOOL_CLASSES = {
     "google_search": GoogleSearch,

--- a/tools/literature_search/__init__.py
+++ b/tools/literature_search/__init__.py
@@ -1,0 +1,7 @@
+# Literature search tool package
+
+from .base import LiteratureSearchTool
+from .arxiv import ArxivSearch
+from .pubmed import PubMedSearch
+
+__all__ = ["LiteratureSearchTool", "ArxivSearch", "PubMedSearch"]

--- a/tools/literature_search/arxiv.py
+++ b/tools/literature_search/arxiv.py
@@ -1,0 +1,29 @@
+import os, requests
+from typing import List
+from xml.etree import ElementTree
+from tsce_agent_demo.models.research_task import PaperMeta
+from .base import LiteratureSearchTool
+
+_ARXIV = "https://export.arxiv.org/api/query"
+
+class ArxivSearch(LiteratureSearchTool):
+    def run(self, query: str, k: int = 10) -> List[PaperMeta]:
+        params = {"search_query": query, "start": 0, "max_results": k}
+        xml = requests.get(_ARXIV, params=params, timeout=30).text
+        root = ElementTree.fromstring(xml)
+        papers: List[PaperMeta] = []
+        for entry in root.findall("{http://www.w3.org/2005/Atom}entry"):
+            papers.append(
+                PaperMeta(
+                    title=entry.findtext("{http://www.w3.org/2005/Atom}title").strip(),
+                    url=entry.findtext("{http://www.w3.org/2005/Atom}id"),
+                    authors=[
+                        a.findtext("{http://www.w3.org/2005/Atom}name")
+                        for a in entry.findall("{http://www.w3.org/2005/Atom}author")
+                    ],
+                    year=int(entry.findtext(
+                        "{http://www.w3.org/2005/Atom}published")[:4]),
+                    abstract=entry.findtext("{http://www.w3.org/2005/Atom}summary").strip(),
+                )
+            )
+        return papers[:k]

--- a/tools/literature_search/base.py
+++ b/tools/literature_search/base.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+from typing import List
+from tsce_agent_demo.models.research_task import PaperMeta
+
+
+class LiteratureSearchTool(ABC):
+    @abstractmethod
+    def run(self, query: str, k: int = 10) -> List[PaperMeta]:
+        ...

--- a/tools/literature_search/pubmed.py
+++ b/tools/literature_search/pubmed.py
@@ -1,0 +1,35 @@
+import os, requests
+from typing import List
+from tsce_agent_demo.models.research_task import PaperMeta
+from .base import LiteratureSearchTool
+
+_EUTILS = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+
+class PubMedSearch(LiteratureSearchTool):
+    def run(self, query: str, k: int = 10) -> List[PaperMeta]:
+        api_key = os.getenv("NCBI_API_KEY")
+        ids = requests.get(
+            f"{_EUTILS}esearch.fcgi",
+            params={"db": "pubmed", "retmode": "json", "term": query, "retmax": k, "api_key": api_key},
+            timeout=30,
+        ).json()["esearchresult"]["idlist"]
+
+        summaries = requests.get(
+            f"{_EUTILS}esummary.fcgi",
+            params={"db": "pubmed", "retmode": "json", "id": ",".join(ids), "api_key": api_key},
+            timeout=30,
+        ).json()["result"]
+
+        papers: List[PaperMeta] = []
+        for pid in ids:
+            meta = summaries[pid]
+            papers.append(
+                PaperMeta(
+                    title=meta["title"],
+                    url=f"https://pubmed.ncbi.nlm.nih.gov/{pid}/",
+                    authors=[a["name"] for a in meta["authors"]],
+                    year=int(meta["pubdate"][:4]),
+                    abstract=meta.get("elocationid", ""),
+                )
+            )
+        return papers

--- a/tsce_agent_demo/models/__init__.py
+++ b/tsce_agent_demo/models/__init__.py
@@ -1,0 +1,2 @@
+from .research_task import PaperMeta
+__all__ = ["PaperMeta"]

--- a/tsce_agent_demo/models/research_task.py
+++ b/tsce_agent_demo/models/research_task.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class PaperMeta:
+    """Basic information about a research paper."""
+
+    title: str
+    url: str
+    authors: List[str]
+    year: int
+    abstract: str


### PR DESCRIPTION
## Summary
- introduce LiteratureSearchTool base and ArxivSearch/PubMedSearch
- expose them through `tools`
- add `PaperMeta` model for search results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d09d47bc8323bff759af5223c92f