### PR TITLE
Implement design_method and MethodPlan model

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 from typing import List
 
+from tsce_demo.models.research_task import ResearchTask
+from tsce_agent_demo.models.research_task import MethodPlan
+from tsce_agent_demo.utils.vector_store import query
+from openai import OpenAI
+
 from .base_agent import BaseAgent, compose_sections
 
 
@@ -30,3 +35,26 @@ class Planner(BaseAgent):
         self.context = message
         output = "\n".join(self.act())
         return compose_sections("", "", output)
+
+
+def design_method(task: ResearchTask, model: str = "gpt-4o-mini") -> ResearchTask:
+    """Generate a JSON MethodPlan using LLM + retrieved evidence."""
+
+    evidence = "\n\n".join(query(task.question, k=8))
+    prompt = f"""You are a lab PI. Draft a JSON experiment plan.
+
+Question: {task.question}
+
+Relevant literature snippets:
+{evidence}
+
+Return ONLY valid JSON matching this schema:
+{MethodPlan.schema_json()}
+"""
+    client = OpenAI()
+    resp = client.chat.completions.create(
+        model=model, messages=[{"role": "user", "content": prompt}]
+    )
+    plan_json = resp.choices[0].message.content
+    task.method_plan = MethodPlan.model_validate_json(plan_json)
+    return task

--- a/tests/test_planner_phase2.py
+++ b/tests/test_planner_phase2.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# provide dummy vector_store before importing planner
+sys.modules.setdefault(
+    "tsce_agent_demo.utils.vector_store",
+    types.SimpleNamespace(query=lambda *a, **k: ["snippet"]),
+)
+
+import agents.planner as planner_mod
+from tsce_demo.models.research_task import ResearchTask
+from tsce_agent_demo.models.research_task import MethodPlan
+
+class DummyClient:
+    def __init__(self, content="{\"steps\": [\"a\"]}"):
+        self.content = content
+        self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self.create))
+    def create(self, model=None, messages=None):
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=self.content))])
+
+def test_design_method_parses_json(monkeypatch):
+    monkeypatch.setattr(planner_mod, "query", lambda q, k=8: ["snippet"])
+    monkeypatch.setattr(planner_mod, "OpenAI", lambda: DummyClient())
+    task = ResearchTask(question="what?")
+    out = planner_mod.design_method(task)
+    assert isinstance(out.method_plan, MethodPlan)
+    assert out.method_plan.steps == ["a"]

--- a/tsce_agent_demo/models/__init__.py
+++ b/tsce_agent_demo/models/__init__.py
@@ -1,2 +1,3 @@
-from .research_task import PaperMeta
-__all__ = ["PaperMeta"]
+from .research_task import PaperMeta, MethodPlan
+
+__all__ = ["PaperMeta", "MethodPlan"]

--- a/tsce_agent_demo/models/research_task.py
+++ b/tsce_agent_demo/models/research_task.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import List
+from typing import Any, List
+
+from pydantic import BaseModel, ConfigDict
 
 @dataclass
 class PaperMeta:
@@ -10,3 +12,10 @@ class PaperMeta:
     authors: List[str]
     year: int
     abstract: str
+
+
+class MethodPlan(BaseModel):
+    """Structured method plan for an experiment."""
+
+    steps: List[str] = []
+    model_config = ConfigDict(extra="allow")

--- a/tsce_agent_demo/utils/vector_store.py
+++ b/tsce_agent_demo/utils/vector_store.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-from langchain.embeddings import OpenAIEmbeddings
-from langchain.vectorstores import FAISS
+try:  # pragma: no cover - optional dependency
+    from langchain.embeddings import OpenAIEmbeddings
+    from langchain.vectorstores import FAISS
+except Exception:  # pragma: no cover
+    OpenAIEmbeddings = None  # type: ignore
+    FAISS = None  # type: ignore
 
 
 def query(text: str, k: int = 5, index_dir: str = "vector_store") -> list[str]:
     """Return the contents of the top-k documents similar to ``text``."""
+    if FAISS is None or OpenAIEmbeddings is None:
+        return []
     store = FAISS.load_local(index_dir, OpenAIEmbeddings())
     docs, _ = store.similarity_search_with_score(text, k=k)
     return [d.page_content for d in docs]


### PR DESCRIPTION
## Summary
- extend planner agent with design_method for phase-2 experiment planning
- make vector_store optional when langchain is unavailable
- add MethodPlan pydantic model and export it
- provide unit test for new design_method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848d33795cc8323b167627178492276