### PR TITLE
Implement demo simulators and result aggregator

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,5 @@
+# Docker Notes
+
+RDKit requires system libraries when building from source on ARM systems.
+Install `libboost-all-dev`, `cmake`, and standard build tools before
+installing the Python package.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -39,3 +39,14 @@ Older versions allowed you to drop or reactivate stages via ``drop_stage()`` and
 ``activate_stage()`` on the orchestrator. These methods remain for backward
 compatibility but are rarely needed now that routing and short‑circuit logic are
 automatic.
+
+## Demo Simulators
+
+| ID  | Parameters | Defaults | Output files |
+|-----|------------|----------|--------------|
+| ode | func, y0, t-span, precision, seed | precision=float64, seed=None | `ode_results.json`, `ode_results.meta.json` |
+| chem | reactants, seed | seed=None | `reaction_product.json`, `reaction_product.meta.json` |
+
+SciPy's ``odeint`` is used for its stability on stiff systems while keeping the
+implementation short. RDKit's ``CombineMols`` merely concatenates molecules as a
+stand-in for real reaction prediction.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ scikit-learn
 sentence-transformers
 matplotlib
 torch
-scipy
+scipy>=1.12,<2
+numpy>=1.26,<2
+rdkit-pypi>=2023.9.5
 pdfplumber
 openai
+

--- a/tests/simulators/test_validation.py
+++ b/tests/simulators/test_validation.py
@@ -1,0 +1,16 @@
+import pytest
+from pathlib import Path
+import importlib
+
+ode = importlib.import_module('tsce_demo.simulators.ode')
+chem = importlib.import_module('tsce_demo.simulators.chem')
+
+
+def test_bad_ode_function():
+    with pytest.raises(ValueError):
+        ode.prepare_inputs("x = y")
+
+
+def test_bad_smiles():
+    with pytest.raises(ValueError):
+        chem.prepare_inputs(["C1CC1C("])

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,0 +1,21 @@
+import importlib
+import pytest
+import tsce_demo.utils.result_aggregator as agg
+
+ode = importlib.import_module("tsce_demo.simulators.ode")
+
+if importlib.util.find_spec("numpy") is None:
+    pytest.skip("numpy not installed", allow_module_level=True)
+
+
+def test_full_pipeline(tmp_path):
+    art = tmp_path / agg.ART_DIR
+    art.mkdir()
+    ode.run_ode("return -0.1*y", 1, 0, 0.1, 0.05, out_dir=art)
+    summary_path = agg.create_summary("decay", tmp_path, bibliography="Ref")
+    assert summary_path.exists()
+    assert summary_path.read_text().strip()
+    assert (art / "ode_results.json").exists()
+
+
+

--- a/tests/test_result_aggregator.py
+++ b/tests/test_result_aggregator.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+import tsce_demo.utils.result_aggregator as agg
+
+
+def test_summary_contains_artifacts(tmp_path):
+    art = tmp_path / agg.ART_DIR
+    art.mkdir()
+    (art / "file1.meta.json").write_text(json.dumps({}))
+    (art / "file2.meta.json").write_text(json.dumps({}))
+    (art / "file3.meta.json").write_text(json.dumps({}))
+
+    biblio = "Paper A\nPaper B\nPaper C"
+    summary = agg.create_summary("Q", tmp_path, bibliography=biblio)
+    text = summary.read_text()
+    assert "file1.meta.json" in text
+    assert text.count("[") == 3

--- a/tsce_demo/__init__.py
+++ b/tsce_demo/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for the TSCE demo."""
+
+__all__ = ["models", "simulators", "utils"]

--- a/tsce_demo/simulators/__init__.py
+++ b/tsce_demo/simulators/__init__.py
@@ -1,0 +1,5 @@
+"""Demo simulators for TSCE experiments."""
+from .ode import run_ode
+from .chem import run_reaction
+
+__all__ = ["run_ode", "run_reaction"]

--- a/tsce_demo/simulators/chem.py
+++ b/tsce_demo/simulators/chem.py
@@ -1,0 +1,77 @@
+"""Minimal chemical reaction demo using RDKit."""
+from __future__ import annotations
+
+import argparse
+import json
+from functools import reduce
+from pathlib import Path
+
+
+def prepare_inputs(smiles: list[str]):
+    """Validate reactant SMILES and return RDKit molecules."""
+    if len(smiles) > 5:
+        raise RuntimeError("Too many reactants")
+    from rdkit import Chem
+
+    mols = []
+    heavy = 0
+    for s in smiles:
+        m = Chem.MolFromSmiles(s)
+        if m is None:
+            raise ValueError(f"Invalid SMILES: {s}")
+        Chem.SanitizeMol(m)
+        mols.append(m)
+        heavy += m.GetNumHeavyAtoms()
+    if heavy > 150:
+        raise RuntimeError("Molecules too large")
+    return mols, heavy
+
+
+def run_reaction(
+    smiles: list[str],
+    *,
+    out_dir: str,
+    seed: int | None = None,
+) -> Path:
+    """Combine molecules and write the product as SMILES."""
+    if seed is not None:
+        import numpy as np
+
+        np.random.seed(seed)
+    mols, heavy = prepare_inputs(smiles)
+    from rdkit import Chem
+
+    prod = reduce(Chem.CombineMols, mols)
+    prod_smiles = Chem.MolToSmiles(prod)
+
+    result = Path(out_dir) / "reaction_product.json"
+    meta = Path(out_dir) / "reaction_product.meta.json"
+    with result.open("w", encoding="utf-8") as f:
+        json.dump({"smiles": prod_smiles}, f)
+    with meta.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "product_smiles": prod_smiles,
+                "n_reactants": len(mols),
+                "heavy_atom_count": heavy,
+            },
+            f,
+        )
+    return result
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run the chemistry simulator")
+    p.add_argument("--reactants", nargs="+", required=True)
+    p.add_argument("--out-dir", default=".")
+    p.add_argument("--seed", type=int, default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    run_reaction(args.reactants, out_dir=args.out_dir, seed=args.seed)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tsce_demo/simulators/ode.py
+++ b/tsce_demo/simulators/ode.py
@@ -1,0 +1,101 @@
+"""Simple ODE integration demo using scipy.odeint."""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from types import FunctionType
+
+
+def prepare_inputs(func_str: str) -> FunctionType:
+    """Compile ``func_str`` into a Python function returning dy/dt."""
+    if "return" not in func_str:
+        raise ValueError("ODE function must contain a return statement")
+    ns: dict[str, object] = {}
+    code = "def f(y, t):\n    " + func_str.replace("\n", "\n    ")
+    try:
+        exec(code, {}, ns)
+    except Exception as exc:  # pragma: no cover - compile error
+        raise ValueError(f"Invalid ODE function: {exc}") from exc
+    func = ns.get("f")
+    if not isinstance(func, FunctionType):
+        raise ValueError("Failed to compile ODE function")
+    return func
+
+
+def run_ode(
+    func_str: str,
+    y0: float,
+    t_start: float,
+    t_end: float,
+    step: float,
+    *,
+    out_dir: str,
+    precision: str = "float64",
+    seed: int | None = None,
+) -> Path:
+    """Run the ODE solver and return the results path."""
+    if seed is not None:
+        import numpy as np
+
+        np.random.seed(seed)
+    func = prepare_inputs(func_str)
+    dtype = "float32" if precision == "float32" else "float64"
+
+    import numpy as np
+    from scipy.integrate import odeint
+
+    t = np.arange(t_start, t_end + step, step, dtype=dtype)
+    if len(t) > 10000:
+        raise RuntimeError("t_span too large")
+    y0 = np.asarray([y0], dtype=dtype)
+
+    start = time.time()
+    y = odeint(func, y0, t)
+    runtime_ms = int((time.time() - start) * 1000)
+
+    result = Path(out_dir) / "ode_results.json"
+    meta = Path(out_dir) / "ode_results.meta.json"
+    with result.open("w", encoding="utf-8") as f:
+        json.dump({"t": t.tolist(), "y": y[:, 0].astype(dtype).tolist()}, f)
+    with meta.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "solver": "odeint",
+                "dtype": dtype,
+                "n_points": len(t),
+                "runtime_ms": runtime_ms,
+            },
+            f,
+        )
+    return result
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run the ODE simulator")
+    p.add_argument("--func", required=True)
+    p.add_argument("--y0", type=float, required=True)
+    p.add_argument("--t-span", nargs=3, type=float, metavar=("START", "END", "STEP"), required=True)
+    p.add_argument("--out-dir", default=".")
+    p.add_argument("--precision", choices=["float32", "float64"], default="float64")
+    p.add_argument("--seed", type=int, default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    run_ode(
+        args.func,
+        args.y0,
+        args.t_span[0],
+        args.t_span[1],
+        args.t_span[2],
+        out_dir=args.out_dir,
+        precision=args.precision,
+        seed=args.seed,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tsce_demo/utils/__init__.py
+++ b/tsce_demo/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility helpers for the TSCE demo."""
+from .result_aggregator import create_summary, gather_artifacts
+
+__all__ = ["create_summary", "gather_artifacts"]

--- a/tsce_demo/utils/result_aggregator.py
+++ b/tsce_demo/utils/result_aggregator.py
@@ -1,0 +1,79 @@
+"""Aggregate simulator artifacts into a Markdown summary."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+ART_DIR = "artifacts"
+LOG_DIR = "logs"
+
+
+def gather_artifacts(work_dir: str | Path) -> list[Path]:
+    work = Path(work_dir)
+    art_dir = work / ART_DIR
+    if not art_dir.is_dir():
+        raise FileNotFoundError(f"{art_dir} missing")
+    files = list(art_dir.iterdir())
+    if not files:
+        raise FileNotFoundError("no artifacts found")
+    return files
+
+
+def _details_block(files: Iterable[Path]) -> str:
+    lines = ["<details>", "<summary>Artifacts</summary>", "", ""]
+    for f in files:
+        try:
+            size = f.stat().st_size
+        except FileNotFoundError:
+            size = 0
+        lines.append(f"- {f.name} ({size} bytes)")
+    lines.append("</details>")
+    return "\n".join(lines)
+
+
+def create_summary(
+    question: str,
+    work_dir: str | Path,
+    bibliography: str,
+    *,
+    style: str = "academic",
+) -> Path:
+    files = gather_artifacts(work_dir)
+    meta_files = [f for f in files if f.name.endswith(".meta.json")]
+    if meta_files:
+        files = meta_files
+    bullet_lines = [f"- Processed {f.name}" for f in files]
+    citations = [f"[{i}] {line}" for i, line in enumerate(bibliography.splitlines(), 1) if line]
+    commit = os.popen("git rev-parse HEAD").read().strip()
+    docker = os.getenv("DOCKER_TAG", "unknown")
+    timestamp = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
+    text = [
+        "# Results",
+        f"**Question:** {question}",
+        "",
+        *bullet_lines,
+        "",
+        *citations,
+        "",
+        "## Reproducibility",
+        f"- Commit: {commit}",
+        f"- Docker: {docker}",
+        f"- Timestamp: {timestamp}",
+        "",
+        _details_block(files),
+    ]
+    summary = "\n".join(text) + "\n"
+    out_path = Path(work_dir) / "summary.md"
+    out_path.write_text(summary, encoding="utf-8")
+    log_dir = Path(work_dir) / LOG_DIR
+    log_dir.mkdir(exist_ok=True)
+    with open(log_dir / "llm_calls.log", "a", encoding="utf-8") as f:
+        f.write(f"summary {len(summary.split())} words\n")
+    return out_path
+
+
+__all__ = ["create_summary", "gather_artifacts"]


### PR DESCRIPTION
## Summary
- add pinned scientific deps
- document RDKit system packages
- create ode and chem simulators
- expose simulators from package root
- implement simple result aggregator
- add documentation about demo simulators
- test validation and aggregator behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d4bb5084832391134efb485eb40c