### PR TITLE
Improve orchestrator error logging

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -63,6 +63,8 @@ Copy `.env.example` to `.env` and populate any keys you plan to use.
    ```
    The script walks through several phases and prints a JSON result when done.
 3. Inspect the generated summary file reported in the output.
+4. If a phase fails, a JSON error report is saved under `logs/` using the
+   run ID, e.g. `logs/orchestrator_failure_<id>.json`.
 
 ## Troubleshooting FAQ
 


### PR DESCRIPTION
## Summary
- persist orchestrator errors to `logs/` using the run id
- document the new error log location in the user guide

## Testing
- `pytest -q -o addopts=''` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6849053e87a48323ad14f807fd7dda39