### PR TITLE
Fix aggregator handling of empty artifacts

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -74,6 +74,6 @@ Copy `.env.example` to `.env` and populate any keys you plan to use.
 | **`RDKit` wheel cannot find `GLIBCXX`** | Ensure your GCC/GLIBC packages are up to date. On Ubuntu, run `sudo apt-get install libstdc++6`. |
 | **401 Unauthorized** | Wrong or expired API key; verify it matches the endpoint type. |
 | **`ValueError: model not found`** | Set `MODEL_NAME` or `AZURE_OPENAI_DEPLOYMENT` correctly in your environment. |
-| **`FileNotFoundError: No summary files found`** | Earlier stages failed and no artifacts were produced. Check `logs/orchestrator_failure_<id>.json` and verify your API keys and dependencies. |
+| **`FileNotFoundError: no artifacts found or artifacts empty`** | Earlier stages failed or produced empty files. Check `logs/orchestrator_failure_<id>.json` and verify your API keys and dependencies. |
 | **`OPENAI_API_KEY environment variable not set`** | Set `OPENAI_API_KEY` or configure Azure/Ollama credentials. |
 

--- a/tests/unit/test_result_aggregator.py
+++ b/tests/unit/test_result_aggregator.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import pytest
 import tsce_demo.utils.result_aggregator as agg
 
 
@@ -15,3 +16,12 @@ def test_summary_contains_artifacts(tmp_path):
     text = summary.read_text()
     assert "file1.meta.json" in text
     assert text.count("[") == 3
+
+
+def test_empty_artifacts_raise(tmp_path):
+    art = tmp_path / agg.ART_DIR
+    art.mkdir()
+    (art / "empty.json").write_text("")
+    with pytest.raises(FileNotFoundError):
+        agg.create_summary("Q", tmp_path, bibliography="")
+

--- a/tsce_demo/utils/result_aggregator.py
+++ b/tsce_demo/utils/result_aggregator.py
@@ -17,9 +17,9 @@ def gather_artifacts(work_dir: str | Path) -> list[Path]:
     art_dir = work / ART_DIR
     if not art_dir.is_dir():
         raise FileNotFoundError(f"{art_dir} missing")
-    files = list(art_dir.iterdir())
+    files = [f for f in art_dir.iterdir() if f.is_file() and f.stat().st_size]
     if not files:
-        raise FileNotFoundError("no artifacts found")
+        raise FileNotFoundError("no artifacts found or artifacts empty")
     return files
 
 


### PR DESCRIPTION
## Summary
- handle empty artifact files in `gather_artifacts`
- document empty artifact error in troubleshooting guide
- test `create_summary` fails when artifact files are blank

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684911d98ca08323ae331e4ef34abaeb