### PR TITLE
Update docs for canonical package name

### DIFF
--- a/.github/workflows/orchestrator-smoke.yml
+++ b/.github/workflows/orchestrator-smoke.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Run orchestrator
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_CI_SMALL }}
-        run: timeout 150 python -m tsce_demo --question "Toy harmonic oscillator"
+        run: timeout 150 python -m tsce_agent_demo --question "Toy harmonic oscillator"

--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ Note: TSCE uses two passes, so raw joules/token cost ≈2× single-shot; we comp
 ### Installation <a name="installation"></a>
 
 ```bash
-git clone https://github.com/<your-username>/tsce_demo.git
-cd tsce_demo
+git clone https://github.com/<your-username>/tsce_agent_demo.git
 cd tsce_agent_demo
 python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
@@ -130,7 +129,7 @@ AZURE_OPENAI_KEY=<azure-key>             # or reuse OPENAI_API_KEY
 ### Quick Start <a name="quick-start"></a>
 
 ```bash
-$ tsce-demo "What is the best catalyst for ..."
+$ tsce-agent-demo "What is the best catalyst for ..."
 {"task_id": "...", "status": "success", "summary_file": ".../summary.md"}
 ```
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -7,8 +7,8 @@ This page collects setup notes and helpful tips for running the demo agents.
 ### Pip
 1. Clone the repository
    ```bash
-   git clone https://github.com/<your-username>/tsce_demo.git
-   cd tsce_demo
+   git clone https://github.com/<your-username>/tsce_agent_demo.git
+   cd tsce_agent_demo
    ```
 2. Create a virtual environment and install requirements
    ```bash
@@ -30,8 +30,8 @@ This page collects setup notes and helpful tips for running the demo agents.
 ### Docker
 A simple Dockerfile is provided. Build and run:
 ```bash
-docker build -t tsce_demo .
-docker run --rm -it tsce_demo
+docker build -t tsce_agent_demo .
+docker run --rm -it tsce_agent_demo
 ```
 If you are on an ARM machine (e.g. Apple Silicon) see the FAQ below.
 
@@ -59,7 +59,7 @@ Copy `.env.example` to `.env` and populate any keys you plan to use.
 1. Ensure your API credentials are set in `.env`.
 2. Run the orchestrator with a question:
    ```bash
-   python -m tsce_demo --question "How does TSCE reduce hallucinations?"
+   python -m tsce_agent_demo --question "How does TSCE reduce hallucinations?"
    ```
    The script walks through several phases and prints a JSON result when done.
 3. Inspect the generated summary file reported in the output.


### PR DESCRIPTION
## Summary
- reference the `tsce_agent_demo` module in docs
- update CI example to run `tsce_agent_demo`

## Testing
- `pip install -e .` *(fails: `setup.py` or `pyproject.toml` not found)*
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*
- `tsce-demo --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849be3a53248323abe2a62376d2a940