### PR TITLE
Remove legacy docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Removed documentation for legacy stage flags and deprecated script.

--- a/README.md
+++ b/README.md
@@ -158,16 +158,6 @@ for msg in orc.run():
 Logs are saved under ``logs/`` by default; set ``LOG_DIR`` in your ``.env`` to
 change this.
 
-Old scripts can still call ``run_legacy()`` to reproduce the original
-round-robin controller:
-
-```python
-history = orc.run_legacy()
-```
-
-When the ``TERMINATE`` token appears, the planner and hypothesis stages are
-deactivated automatically. The remaining agents finish the job without any manual
-stage toggling.
 
 Sample ``hello world`` session:
 
@@ -209,7 +199,7 @@ stage.
 Run the orchestrator directly from the command line:
 
 ```bash
-python tsce_agent_demo/run_orchestrator.py "Print hello world" TERMINATE
+python -m tsce_agent_demo --question "Print hello world"
 ```
 
 Additional utilities:

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -33,13 +33,6 @@ task such as printing ``hello world``, planning is skipped and later stages run
 immediately. This short‑circuit behaviour lets simple prompts finish without any
 manual stage management.
 
-## Legacy Manual Control
-
-Older versions allowed you to drop or reactivate stages via ``drop_stage()`` and
-``activate_stage()`` on the orchestrator. These methods remain for backward
-compatibility but are rarely needed now that routing and short‑circuit logic are
-automatic.
-
 ## Demo Simulators
 
 | ID  | Parameters | Defaults | Output files |


### PR DESCRIPTION
## Summary
- remove docs about drop_stage and run_legacy
- update CLI usage in README
- add changelog entry

## Testing
- `pytest -q` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6849c45b77148323850b45d1d56a698a