### PR TITLE
Add index existence check in vector store

### DIFF
--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -1,0 +1,30 @@
+import types
+import pytest
+from tsce_agent_demo.utils import vector_store
+
+
+def test_query_missing_index(tmp_path, monkeypatch):
+    monkeypatch.setattr(vector_store, "FAISS", object())
+    monkeypatch.setattr(vector_store, "OpenAIEmbeddings", lambda: None)
+    with pytest.raises(FileNotFoundError):
+        vector_store.query("q", index_dir=tmp_path / "nope")
+
+
+def test_query_existing_index(tmp_path, monkeypatch):
+    index_dir = tmp_path / "vec"
+    index_dir.mkdir()
+
+    dummy_store = types.SimpleNamespace(
+        similarity_search_with_score=lambda text, k=5: ([types.SimpleNamespace(page_content="hit")], None)
+    )
+
+    class DummyFAISS:
+        @staticmethod
+        def load_local(path, embeddings):
+            assert path == str(index_dir)
+            return dummy_store
+
+    monkeypatch.setattr(vector_store, "FAISS", DummyFAISS)
+    monkeypatch.setattr(vector_store, "OpenAIEmbeddings", lambda: None)
+    result = vector_store.query("q", index_dir=str(index_dir))
+    assert result == ["hit"]

--- a/tsce_agent_demo/utils/vector_store.py
+++ b/tsce_agent_demo/utils/vector_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 try:  # pragma: no cover - optional dependency
     from langchain.embeddings import OpenAIEmbeddings
     from langchain.vectorstores import FAISS
@@ -14,6 +16,12 @@ def query(text: str, k: int = 5, index_dir: str = "vector_store") -> list[str]:
     """Return the contents of the top-k documents similar to ``text``."""
     if FAISS is None or OpenAIEmbeddings is None:
         return []
-    store = FAISS.load_local(index_dir, OpenAIEmbeddings())
+    path = Path(index_dir)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Vector store directory '{index_dir}' not found. "
+            "Run the ingest step to build it."
+        )
+    store = FAISS.load_local(str(path), OpenAIEmbeddings())
     docs, _ = store.similarity_search_with_score(text, k=k)
     return [d.page_content for d in docs]


### PR DESCRIPTION
## Summary
- validate vector store directory exists before loading
- add unit tests for vector store query edge cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_6849c66e584c8323ba36d88e988c9b69