### PR TITLE
Pass MethodPlan to ScriptWriter

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -14,6 +14,7 @@ from .planner import Planner
 from .scientist import Scientist
 from .researcher import Researcher
 from .script_writer import ScriptWriter
+from tsce_agent_demo.models.research_task import MethodPlan
 from .script_qa import ScriptQA
 from .simulator import Simulator
 from .evaluator import Evaluator
@@ -259,7 +260,15 @@ class Orchestrator:
                     self.drop_stage("script")
 
                 if self.stages.get("script") and need_code:
-                    script, gid = self.script_writer.act(plan)
+                    steps = []
+                    for line in plan.splitlines():
+                        line = line.strip()
+                        if not line:
+                            continue
+                        line = re.sub(r"^Step\s*\d+\s*:\s*", "", line, flags=re.I)
+                        steps.append(line)
+                    method_plan = MethodPlan(steps=steps or [plan])
+                    script, gid = self.script_writer.act(method_plan)
                     script = self._sanitize_script(script)
                     self.history.append({"role": "script_writer", "content": script})
                     path = os.path.join(

--- a/agents/script_writer.py
+++ b/agents/script_writer.py
@@ -4,6 +4,8 @@ import re
 import textwrap
 import uuid
 
+from tsce_agent_demo.models.research_task import MethodPlan
+
 from .base_agent import BaseAgent
 
 
@@ -17,14 +19,19 @@ class ScriptWriter(BaseAgent):
         return self.act(message)
 
     # ------------------------------------------------------------------
-    def act(self, request: str) -> tuple[str, str]:
+    def act(self, request: MethodPlan | str) -> tuple[str, str]:
         """Return a short Python code snippet for ``request``.
 
         The implementation is intentionally lightweight and recognises only a
         few common patterns.  If the request cannot be handled, a comment
         describing the limitation is returned instead of code.
         """
-        lower = request.lower()
+        if isinstance(request, MethodPlan):
+            req_str = " ".join(request.steps)
+        else:
+            req_str = request
+
+        lower = req_str.lower()
         gid = uuid.uuid4().hex
 
         if "hello" in lower and "world" in lower:
@@ -61,7 +68,7 @@ class ScriptWriter(BaseAgent):
             script = f"# GOLDEN_THREAD:{gid}\n{script}"
             return script, gid
 
-        script = f"# TODO: unable to generate script for: {request}"
+        script = f"# TODO: unable to generate script for: {req_str}"
         script = f"# GOLDEN_THREAD:{gid}\n{script}"
         return script, gid
 

--- a/tests/unit/test_script_writer.py
+++ b/tests/unit/test_script_writer.py
@@ -6,6 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 import agents.script_writer as script_writer_mod
 import agents.base_agent as base_agent_mod
+from tsce_agent_demo.models.research_task import MethodPlan
 
 class DummyChat:
     def __init__(self, *args, **kwargs):
@@ -18,8 +19,9 @@ class DummyChat:
 def test_golden_thread_comment_unique(monkeypatch):
     monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
     sw = script_writer_mod.ScriptWriter()
-    script1, gid1 = sw.act("hello world")
-    script2, gid2 = sw.act("hello world")
+    plan = MethodPlan(steps=["hello world"])
+    script1, gid1 = sw.act(plan)
+    script2, gid2 = sw.act(plan)
     assert script1.startswith(f"# GOLDEN_THREAD:{gid1}")
     assert script2.startswith(f"# GOLDEN_THREAD:{gid2}")
     assert gid1 != gid2


### PR DESCRIPTION
## Summary
- pass MethodPlan objects into ScriptWriter
- parse MethodPlan in ScriptWriter
- update tests to call ScriptWriter with MethodPlan

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tsce_agent_demo')*

------
https://chatgpt.com/codex/tasks/task_e_6849c929de0083239a097eccf8ac65d7