### PR TITLE
Add sandbox Docker build

### DIFF
--- a/.github/workflows/build-sandbox.yml
+++ b/.github/workflows/build-sandbox.yml
@@ -1,0 +1,28 @@
+name: build-sandbox
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/tsce_sandbox:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Install system dependencies for building wheels like RDKit
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        libboost-all-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
 pip install -e .
 cp .env.example .env          # then edit .env with your creds
+# If you need a ready-to-use environment, pull the sandbox image:
+```bash
+docker run --rm -it ghcr.io/<owner>/tsce_sandbox:latest
+```
 ---
 
 ### Configuration <a name="configuration"></a>

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,3 +3,9 @@
 RDKit requires system libraries when building from source on ARM systems.
 Install `libboost-all-dev`, `cmake`, and standard build tools before
 installing the Python package.
+
+For environments without a local sandbox, pull the image from GHCR:
+
+```bash
+docker run --rm -it ghcr.io/<owner>/tsce_sandbox:latest
+```

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -32,6 +32,7 @@ A simple Dockerfile is provided. Build and run:
 ```bash
 docker build -t tsce_agent_demo .
 docker run --rm -it tsce_agent_demo
+docker run --rm -it ghcr.io/<owner>/tsce_sandbox:latest
 ```
 If you are on an ARM machine (e.g. Apple Silicon) see the FAQ below.
 


### PR DESCRIPTION
## Summary
- add Dockerfile for tsce_sandbox
- build/push container on pushes to main
- mention pre-built sandbox image in docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6849db7467ac8323b12f0becd8500dcc