### PR TITLE
Add test for OpenAI v1 API usage

### DIFF
--- a/tests/unit/test_chat_api.py
+++ b/tests/unit/test_chat_api.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+# Provide a minimal 'openai' module so tsce_chat imports succeed
+sys.modules.setdefault(
+    "openai",
+    types.SimpleNamespace(BaseClient=object, AzureOpenAI=object),
+)
+
+import tsce_agent_demo.tsce_chat as chat_mod
+
+class DummyClient:
+    def __init__(self):
+        self.called = False
+        self.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=self.create)
+        )
+    def create(self, **kwargs):
+        self.called = True
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))],
+            model="dummy",
+            model_dump=lambda: {
+                "choices": [{"message": {"content": "ok"}}],
+                "model": "dummy",
+                "usage": {}
+            },
+        )
+
+def test_completion_uses_chat_completions():
+    client = DummyClient()
+    chat = chat_mod.TSCEChat(client=client)
+    chat._completion([{"role": "user", "content": "hi"}])
+    assert client.called


### PR DESCRIPTION
## Summary
- ensure that TSCEChat uses `client.chat.completions.create` by mocking the client

## Testing
- `pytest tests/unit/test_chat_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849de26bde08323a74e801a5d31c32f