### PR TITLE
Simplify tests with mock fixture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# copy to .env and fill your own values
+# copy to .env if running with real credentials
 OPENAI_API_KEY=sk-***************************
 # optional overrides
 # OPENAI_ENDPOINT=https://api.openai.com/v1/chat/completions

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# Test Suite
+
+All tests run without contacting external APIs. The `mock_tsce_chat` fixture in
+`tests/conftest.py` replaces `tsce_agent_demo.tsce_chat.TSCEChat` with a simple
+dummy implementation and sets a dummy `OPENAI_API_KEY`.
+
+Use the fixture by adding `mock_tsce_chat` as an argument to your test. Most
+unit tests depend on it implicitly and therefore do not require any real API
+credentials.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import types
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+sys.modules.setdefault(
+    "openai",
+    types.SimpleNamespace(OpenAI=object, BaseClient=object, AzureOpenAI=object),
+)
+
+import tsce_agent_demo.tsce_chat as tsce_chat
+import agents.base_agent as base_agent
+import agents.orchestrator as orchestrator
+import agents.researcher as researcher
+
+class DummyChat:
+    def __call__(self, messages):
+        if isinstance(messages, list):
+            content = messages[-1]["content"]
+        else:
+            content = messages
+        return types.SimpleNamespace(content=content)
+
+def _install(monkeypatch, dummy):
+    monkeypatch.setattr(tsce_chat, "_make_client", lambda: ("dummy", object(), ""))
+    monkeypatch.setattr(tsce_chat, "TSCEChat", lambda model=None: dummy)
+    monkeypatch.setattr(base_agent, "TSCEChat", lambda model=None: dummy)
+    monkeypatch.setattr(orchestrator, "TSCEChat", lambda model=None: dummy)
+    monkeypatch.setattr(researcher, "TSCEChat", lambda model=None: dummy)
+
+@pytest.fixture
+def mock_tsce_chat(monkeypatch):
+    dummy = DummyChat()
+    _install(monkeypatch, dummy)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    return dummy
+

--- a/tests/int/test_orchestrator_e2e.py
+++ b/tests/int/test_orchestrator_e2e.py
@@ -22,10 +22,8 @@ class DummyChat:
         return self.total_tokens, self.total_cost_usd
 
 
-def test_orchestrator_end_to_end(tmp_path, monkeypatch):
-    monkeypatch.setattr(chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setenv("OPENAI_API_KEY", "test")
+def test_orchestrator_end_to_end(tmp_path, mock_tsce_chat, monkeypatch):
+    monkeypatch.setattr(chat_mod, "TSCEChat", lambda model=None: mock_tsce_chat)
 
     out_json = tmp_path / "run.json"
     monkeypatch.setattr(sys, "argv", [

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -62,11 +62,6 @@ class DummyQA:
 
 
 def _patch_all(monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
     monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(orchestrator_mod, "Evaluator", lambda *a, **kw: DummyEvaluator())
@@ -79,9 +74,8 @@ def _patch_all(monkeypatch):
 
 # ---------------------------------------------------------------------------
 
-def test_queue_simple_goal(tmp_path, monkeypatch):
+def test_queue_simple_goal(tmp_path, mock_tsce_chat, monkeypatch):
     _patch_all(monkeypatch)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(["tell me a joke", "terminate"], model="test", output_dir=str(tmp_path))
     history = orch.run()
@@ -93,9 +87,8 @@ def test_queue_simple_goal(tmp_path, monkeypatch):
     assert "simulator" not in roles
 
 
-def test_queue_complex_goal(tmp_path, monkeypatch):
+def test_queue_complex_goal(tmp_path, mock_tsce_chat, monkeypatch):
     _patch_all(monkeypatch)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(["compute fibonacci 5", "terminate"], model="test", output_dir=str(tmp_path))
     history = orch.run()
@@ -106,10 +99,9 @@ def test_queue_complex_goal(tmp_path, monkeypatch):
     assert "final_qa" in roles
 
 
-def test_queue_multi_agent_dialogue(tmp_path, monkeypatch):
+def test_queue_multi_agent_dialogue(tmp_path, mock_tsce_chat, monkeypatch):
     """End-to-end dialogue across planner, scientist, researcher, and judge."""
     _patch_all(monkeypatch)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(["calculate factorial 4", "terminate"], model="test", output_dir=str(tmp_path))
     history = orch.run()

--- a/tests/unit/test_orchestrator_hypothesis_stage.py
+++ b/tests/unit/test_orchestrator_hypothesis_stage.py
@@ -32,15 +32,9 @@ class DummyResearcher:
     def read_file(self, path):
         return Path(path).read_text() if Path(path).exists() else ""
 
-def test_hypothesis_stage_deactivated(tmp_path, monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+def test_hypothesis_stage_deactivated(tmp_path, mock_tsce_chat, monkeypatch):
     monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
     orch.drop_stage("script")

--- a/tests/unit/test_orchestrator_judge_loop.py
+++ b/tests/unit/test_orchestrator_judge_loop.py
@@ -52,15 +52,9 @@ class DummyJudgePanel:
         return True
 
 
-def test_script_files_have_unique_names_and_marker(tmp_path, monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+def test_script_files_have_unique_names_and_marker(tmp_path, mock_tsce_chat, monkeypatch):
     monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(
         [
@@ -87,17 +81,11 @@ def test_script_files_have_unique_names_and_marker(tmp_path, monkeypatch):
         assert s.read_text().startswith("# GOLDEN_THREAD:")
 
 
-def test_judge_rejection_causes_retry(tmp_path, monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+def test_judge_rejection_causes_retry(tmp_path, mock_tsce_chat, monkeypatch):
     monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(orchestrator_mod, "Evaluator", DummyEvaluator)
     monkeypatch.setattr(orchestrator_mod, "JudgePanel", DummyJudgePanel)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(
         ["compute fibonacci 2", "terminate"],

--- a/tests/unit/test_orchestrator_output.py
+++ b/tests/unit/test_orchestrator_output.py
@@ -34,15 +34,9 @@ class DummyResearcher:
         return Path(path).read_text() if Path(path).exists() else ""
 
 
-def test_output_files_created(tmp_path, monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+def test_output_files_created(tmp_path, mock_tsce_chat, monkeypatch):
     monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
     orch.drop_stage("script")
@@ -59,15 +53,9 @@ def test_output_files_created(tmp_path, monkeypatch):
     assert (run_path / "research.txt").exists()
 
 
-def test_research_file_appends(tmp_path, monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+def test_research_file_appends(tmp_path, mock_tsce_chat, monkeypatch):
     monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator([
         "goal1",

--- a/tests/unit/test_run_legacy.py
+++ b/tests/unit/test_run_legacy.py
@@ -14,16 +14,7 @@ class DummyChat:
         return types.SimpleNamespace(content=content)
 
 
-def _patch(monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-
-
-def test_run_legacy_round_robin(tmp_path, monkeypatch):
-    _patch(monkeypatch)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+def test_run_legacy_round_robin(tmp_path, mock_tsce_chat):
 
     orch = orchestrator_mod.Orchestrator(["goal", "terminate"], model="test", output_dir=str(tmp_path))
     history = orch.run_legacy()

--- a/tests/unit/test_trivial_goal.py
+++ b/tests/unit/test_trivial_goal.py
@@ -44,16 +44,10 @@ class DummyJudgePanel:
         return True
 
 
-def test_hello_world_bypasses_pipeline(tmp_path, monkeypatch):
-    monkeypatch.setattr(tsce_chat_mod, "_make_client", lambda: ("dummy", object(), ""))
-    monkeypatch.setattr(tsce_chat_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(base_agent_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(orchestrator_mod, "TSCEChat", lambda model=None: DummyChat())
-    monkeypatch.setattr(researcher_mod, "TSCEChat", lambda model=None: DummyChat())
+def test_hello_world_bypasses_pipeline(tmp_path, mock_tsce_chat, monkeypatch):
     monkeypatch.setattr(orchestrator_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(researcher_mod, "Researcher", DummyResearcher)
     monkeypatch.setattr(orchestrator_mod, "JudgePanel", DummyJudgePanel)
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     orch = orchestrator_mod.Orchestrator(["print hello world", "terminate"], model="test", output_dir=str(tmp_path))
     history = orch.run()


### PR DESCRIPTION
## Summary
- remove API key requirement from tests
- add global fixture to mock `TSCEChat`
- document the mock in `tests/README.md`
- update unit tests to use the fixture
- clarify `.env.example` comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684a011858f08323833750c17fdf21f9