### PR TITLE
Fix README quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ AZURE_OPENAI_KEY=<azure-key>             # or reuse OPENAI_API_KEY
 ### Quick Start <a name="quick-start"></a>
 
 ```bash
-$ tsce-agent-demo "What is the best catalyst for ..."
+$ python -m tsce_agent_demo.run_orchestrator "What is the best catalyst for ..."
 {"task_id": "...", "status": "success", "summary_file": ".../summary.md"}
 ```
 


### PR DESCRIPTION
## Summary
- show new CLI invocation in the README

## Testing
- `pytest -p no:cov -o addopts='' -q` *(fails: tests/unit/test_orchestrator_cli.py::test_aborts_on_overrun, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684a2d2b17a08323af0a911eaef84d95