### PR TITLE
Add benchmark badge and update script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: results-badge
+results-badge:
+	python tools/update_results_badge.py

--- a/results/README.md
+++ b/results/README.md
@@ -1,3 +1,5 @@
+![Benchmarks](https://img.shields.io/badge/benchmarks-fb48f29-blue)
+
 The `results/` directory stores simulation artifacts generated during tests and orchestrator runs.
 
 * `*.log` files contain raw stdout/stderr produced by executed Python scripts.

--- a/tools/update_results_badge.py
+++ b/tools/update_results_badge.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Update the benchmark commit badge in results/README.md."""
+from pathlib import Path
+import subprocess
+
+
+def main() -> None:
+    sha = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+    readme = Path("results/README.md")
+    lines = readme.read_text().splitlines()
+    badge = f"![Benchmarks](https://img.shields.io/badge/benchmarks-{sha}-blue)"
+
+    if lines and lines[0].startswith("![Benchmarks]"):
+        lines[0] = badge
+    else:
+        lines.insert(0, badge)
+        lines.insert(1, "")
+
+    readme.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a commit badge to `results/README.md`
- add helper script `tools/update_results_badge.py`
- create a `results-badge` Makefile target

## Testing
- `pytest -q -o addopts='' tests/unit tests/int` *(fails: pydantic.ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_684a3792b2888323841a6422dac60311