### PR TITLE
Fix CLI cost check and Pydantic defaults

### DIFF
--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -5,10 +5,20 @@ class ValidationError(Exception):
 
 class BaseModel:
     def __init__(self, **data):
+        """Populate fields declared in ``__annotations__`` allowing defaults."""
         anns = getattr(self.__class__, '__annotations__', {})
+        # First, set annotated fields either from provided data or defaults
         for name in anns:
-            if name not in data:
+            if name in data:
+                value = data.pop(name)
+                setattr(self, name, value)
+            elif hasattr(self.__class__, name):
+                # honour class level defaults (e.g. ``field: int = 1``)
+                setattr(self, name, getattr(self.__class__, name))
+            else:
                 raise ValidationError(f"Missing field: {name}")
+
+        # Store any extra fields directly on the instance
         for k, v in data.items():
             setattr(self, k, v)
 


### PR DESCRIPTION
## Summary
- support default values in BaseModel
- create output summary independent of `create_summary` return value and check cost safely
- add fixtures folder for integration tests

## Testing
- `pytest -q -o addopts='' tests/unit tests/int`

------
https://chatgpt.com/codex/tasks/task_e_684a3869cc6c8323898bffaf22fc63a8