### PR TITLE
Replace curl with requests downloader

### DIFF
--- a/tests/unit/test_pdf_ingest.py
+++ b/tests/unit/test_pdf_ingest.py
@@ -1,0 +1,75 @@
+import types
+import threading
+import http.server
+from contextlib import contextmanager
+
+import pip._vendor.requests as real_requests
+import tools.ingest.pdf_ingest as pdf_ingest
+
+
+class DummyStore:
+    def __init__(self):
+        self.texts = []
+        self.metas = []
+
+    def add_texts(self, texts, metadatas):
+        self.texts.extend(texts)
+        self.metas.extend(metadatas)
+
+    def save_local(self, path):
+        self.saved = path
+
+
+class DummyFAISS:
+    def __init__(self, *a):
+        self.store = DummyStore()
+
+    def add_texts(self, *a, **kw):
+        return self.store.add_texts(*a, **kw)
+
+    def save_local(self, path):
+        return self.store.save_local(path)
+
+
+@contextmanager
+def serve(code=200, data=b"file"):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(code)
+            self.end_headers()
+            if code == 200:
+                self.wfile.write(data)
+
+    httpd = http.server.HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    try:
+        yield f"http://localhost:{httpd.server_port}"
+    finally:
+        httpd.shutdown()
+        thread.join()
+
+
+def test_download_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(pdf_ingest, "OpenAIEmbeddings", lambda: types.SimpleNamespace(embed_query=lambda x: x, embedding_size=1))
+    monkeypatch.setattr(pdf_ingest, "FAISS", DummyFAISS)
+    monkeypatch.setattr(pdf_ingest.subprocess, "check_output", lambda *a, **kw: b"text")
+    monkeypatch.setattr(pdf_ingest, "requests", real_requests)
+
+    with serve() as base:
+        paper = types.SimpleNamespace(url=f"{base}/p.pdf", title="t")
+        pdf_ingest.ingest_papers([paper], index_dir=str(tmp_path))
+
+
+def test_download_http_error(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(pdf_ingest, "OpenAIEmbeddings", lambda: types.SimpleNamespace(embed_query=lambda x: x, embedding_size=1))
+    monkeypatch.setattr(pdf_ingest, "FAISS", DummyFAISS)
+    monkeypatch.setattr(pdf_ingest.subprocess, "check_output", lambda *a, **kw: (_ for _ in ()).throw(AssertionError("should not call")))
+    monkeypatch.setattr(pdf_ingest, "requests", real_requests)
+
+    with serve(404) as base:
+        paper = types.SimpleNamespace(url=f"{base}/p.pdf", title="t")
+        caplog.set_level("ERROR")
+        pdf_ingest.ingest_papers([paper], index_dir=str(tmp_path))
+        assert any("404" in r.message for r in caplog.records)

--- a/tools/ingest/pdf_ingest.py
+++ b/tools/ingest/pdf_ingest.py
@@ -2,15 +2,34 @@
 
 from __future__ import annotations
 
-import json
-import os
+import logging
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Iterable
 
+import requests
+
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.vectorstores import FAISS
+
+
+def _download_pdf(url: str, dest: Path, retries: int = 3, timeout: int = 10) -> bool:
+    """Download *url* to *dest*, retrying on failure."""
+    for attempt in range(retries):
+        try:
+            resp = requests.get(url, timeout=timeout)
+            if resp.status_code >= 400:
+                logging.error("HTTP error %s while downloading %s", resp.status_code, url)
+                return False
+            dest.write_bytes(resp.content)
+            return True
+        except Exception as exc:  # pragma: no cover - network issues
+            if attempt == retries - 1:
+                logging.error("Download failed for %s: %s", url, exc)
+            else:
+                continue
+    return False
 
 
 def ingest_papers(papers: Iterable, index_dir: str = "vector_store") -> None:
@@ -36,7 +55,8 @@ def ingest_papers(papers: Iterable, index_dir: str = "vector_store") -> None:
 
         with tempfile.TemporaryDirectory() as tmp:
             pdf_path = Path(tmp) / "paper.pdf"
-            subprocess.check_call(["curl", "-L", url, "-o", pdf_path])
+            if not _download_pdf(url, pdf_path):
+                continue
             txt = subprocess.check_output(["python", "-m", "pypdf", pdf_path])
             chunks = [txt[i : i + 1000] for i in range(0, len(txt), 1000)]
             store.add_texts(chunks, metadatas=[{"title": title}] * len(chunks))


### PR DESCRIPTION
## Summary
- download PDFs using `requests` with retry logic instead of `curl`
- log HTTP errors when downloads fail
- add unit tests for the new downloader using a mocked HTTP server

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov=...)*

------
https://chatgpt.com/codex/tasks/task_e_684a3a3ecb2483238efb416507461fe7