### PR TITLE
Limit planner output to five steps

### DIFF
--- a/agents/planner.py
+++ b/agents/planner.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import List
 
+MAX_STEPS = 5
+
 from tsce_agent_demo.models.research_task import ResearchTask
 from tsce_agent_demo.models.research_task import MethodPlan
 from tsce_agent_demo.utils.vector_store import query
@@ -28,6 +30,8 @@ class Planner(BaseAgent):
         parts = [p.strip() for p in context.splitlines() if p.strip()]
         if len(parts) <= 1:
             parts = [p.strip() for p in context.split(".") if p.strip()]
+
+        parts = parts[:MAX_STEPS]
 
         return [f"Step {i + 1}: {part}" for i, part in enumerate(parts)]
 

--- a/tests/unit/test_planner_phase1.py
+++ b/tests/unit/test_planner_phase1.py
@@ -46,3 +46,11 @@ def test_act_empty_context():
     planner = make_planner()
     planner.context = "   "
     assert planner.act() == ["Step 1: No context provided."]
+
+
+def test_act_limits_steps():
+    planner = make_planner()
+    planner.context = "\n".join(str(i) for i in range(7))
+    assert planner.act() == [
+        f"Step {i + 1}: {i}" for i in range(planner_mod.MAX_STEPS)
+    ]


### PR DESCRIPTION
## Summary
- cap generated planner steps at five using MAX_STEPS
- add a unit test ensuring planner truncates plans

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeac97ec88323a36ad158e53414d2