### PR TITLE
Add Biopython dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "openai",
     "langchain",
     "faiss-cpu",
+    "biopython>=1.83",  # for Entrez PubMed
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pdfplumber
 openai
 langchain
 faiss-cpu
+biopython>=1.83  # for Entrez PubMed


### PR DESCRIPTION
## Summary
- add `biopython>=1.83` to `requirements.txt`
- list Biopython in `pyproject.toml` for packaging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aee29b9588323bf88cdadc9bd704a